### PR TITLE
Supprimer les sections Chantier et réutiliser leurs images

### DIFF
--- a/src/components/blocks/home/HomeCards.tsx
+++ b/src/components/blocks/home/HomeCards.tsx
@@ -1,61 +1,51 @@
 import { CheckCircle2, ShieldCheck } from "lucide-react";
 import { SiteIllustration } from "@/components/blocks/SiteIllustration";
-import type { OfferTrack, RiskCard as RiskCardContent } from "./types";
+import type { RiskCard as RiskCardData } from "./types";
+
+const RiskCardBody = ({ risk }: { risk: RiskCardData }) => (
+	<>
+		<div className="flex items-center justify-between">
+			<h3 className="terminal-heading pr-8 text-lg">{risk.title}</h3>
+			<ShieldCheck className="size-5 text-secondary" />
+		</div>
+		<p className="terminal-muted mt-3 text-sm">{risk.description}</p>
+		<p className="terminal-muted mt-5 flex items-start gap-2 text-sm">
+			<CheckCircle2 className="mt-0.5 size-4 shrink-0 text-secondary" />
+			{risk.bullet}
+		</p>
+	</>
+);
 
 export function RiskCard({
 	risk,
 	index,
 }: {
-	risk: RiskCardContent;
+	risk: RiskCardData;
 	index: number;
 }) {
+	if (risk.illustrationUrl) {
+		return (
+			<article
+				className="terminal-card grid overflow-hidden p-3 motion-safe:animate-fade-up md:grid-cols-[0.8fr_1fr]"
+				style={{ animationDelay: `${index * 120}ms` }}
+			>
+				<SiteIllustration
+					src={risk.illustrationUrl}
+					className="box-border aspect-[3/2] min-w-0 max-w-full self-stretch justify-self-stretch"
+				/>
+				<div className="flex flex-col p-3 pt-5 md:p-5">
+					<RiskCardBody risk={risk} />
+				</div>
+			</article>
+		);
+	}
+
 	return (
 		<div
 			className="terminal-card p-6 motion-safe:animate-fade-up"
 			style={{ animationDelay: `${index * 120}ms` }}
 		>
-			<div className="flex items-center justify-between">
-				<h3 className="terminal-heading pr-8 text-lg">{risk.title}</h3>
-				<ShieldCheck className="size-5 text-secondary" />
-			</div>
-			<p className="terminal-muted mt-3 text-sm">{risk.description}</p>
-			<p className="terminal-muted mt-5 flex items-start gap-2 text-sm">
-				<CheckCircle2 className="mt-0.5 size-4 shrink-0 text-secondary" />
-				{risk.bullet}
-			</p>
+			<RiskCardBody risk={risk} />
 		</div>
-	);
-}
-
-export function OfferTrackCard({
-	track,
-	index,
-}: {
-	track: OfferTrack;
-	index: number;
-}) {
-	return (
-		<article
-			className="terminal-card grid overflow-hidden p-3 motion-safe:animate-fade-up md:grid-cols-[0.8fr_1fr] lg:grid-cols-1"
-			style={{ animationDelay: `${(index + 4) * 120}ms` }}
-		>
-			<SiteIllustration
-				src={track.illustrationUrl}
-				className="box-border aspect-[3/2] min-w-0 max-w-full self-stretch justify-self-stretch"
-			/>
-			<div className="flex flex-col p-3 pt-5 md:p-5 lg:p-3 lg:pt-5">
-				<p className="terminal-label">{track.label}</p>
-				<h3 className="terminal-heading mt-3 text-xl">{track.title}</h3>
-				<p className="terminal-muted mt-3 text-sm">{track.description}</p>
-				<ul className="mt-5 grid gap-3 text-sm">
-					{track.bullets.map((bullet) => (
-						<li key={bullet} className="terminal-muted flex items-start gap-2">
-							<CheckCircle2 className="mt-0.5 size-4 shrink-0 text-secondary" />
-							<span>{bullet}</span>
-						</li>
-					))}
-				</ul>
-			</div>
-		</article>
 	);
 }

--- a/src/components/blocks/home/HomePage.tsx
+++ b/src/components/blocks/home/HomePage.tsx
@@ -38,7 +38,7 @@ export function HomePage({ assets }: { assets: HomeAssets }) {
 				capture={capture}
 				brandAlt={t((t) => t.nav.brand)}
 			/>
-			<HomeServicesSection assets={assets} content={content} />
+			<HomeServicesSection content={content} />
 			<HomeTestimonialsSection assets={assets} content={content} />
 			<HomeMethodSection content={content} />
 			<HomeFinalCta content={content.cta} capture={capture} />

--- a/src/components/blocks/home/HomeSections.tsx
+++ b/src/components/blocks/home/HomeSections.tsx
@@ -5,7 +5,7 @@ import { SiteIllustration } from "@/components/blocks/SiteIllustration";
 import { Button } from "@/components/ui/button";
 import { ANALYTICS_EVENTS, type useAnalytics } from "@/lib/analytics";
 import { SCHEDULE_VISIO_URL } from "@/lib/constants";
-import { OfferTrackCard, RiskCard } from "./HomeCards";
+import { RiskCard } from "./HomeCards";
 import { MigrationJourney } from "./MigrationJourney";
 import { TestimonialConsole } from "./TestimonialConsole";
 import type { HomeAssets, HomeContent } from "./types";
@@ -103,11 +103,9 @@ export function HomeHeroSection({
 }
 
 export function HomeServicesSection({
-	assets,
 	content,
 }: {
-	assets: Pick<HomeAssets, "risksIllustrationUrl">;
-	content: Pick<HomeContent, "servicesSection" | "riskCards" | "offerTracks">;
+	content: Pick<HomeContent, "servicesSection" | "riskCards">;
 }) {
 	return (
 		// biome-ignore lint/correctness/useUniqueElementIds: anchor targets
@@ -126,20 +124,9 @@ export function HomeServicesSection({
 						{content.servicesSection.description}
 					</p>
 				</div>
-				<div className="mt-10 grid gap-8 lg:grid-cols-[0.9fr_1.1fr] lg:items-stretch">
-					<SiteIllustration
-						src={assets.risksIllustrationUrl}
-						className="aspect-[4/3] lg:aspect-auto"
-					/>
-					<div className="grid gap-6 md:grid-cols-2">
-						{content.riskCards.map((risk, index) => (
-							<RiskCard key={risk.title} index={index} risk={risk} />
-						))}
-					</div>
-				</div>
-				<div className="mt-10 grid gap-6 lg:grid-cols-2">
-					{content.offerTracks.map((track, index) => (
-						<OfferTrackCard key={track.title} track={track} index={index} />
+				<div className="mt-10 grid gap-6 md:grid-cols-2">
+					{content.riskCards.map((risk, index) => (
+						<RiskCard key={risk.title} index={index} risk={risk} />
 					))}
 				</div>
 			</div>

--- a/src/components/blocks/home/content.ts
+++ b/src/components/blocks/home/content.ts
@@ -79,45 +79,25 @@ export function buildHomeContent(
 				title: t((t) => t.home.risks.native.title),
 				description: t((t) => t.home.risks.native.description),
 				bullet: t((t) => t.home.risks.native.bullet),
+				illustrationUrl: assets.legacyServiceIllustrationUrl,
 			},
 			{
 				title: t((t) => t.home.risks.delivery.title),
 				description: t((t) => t.home.risks.delivery.description),
 				bullet: t((t) => t.home.risks.delivery.bullet),
+				illustrationUrl: assets.workflowServiceIllustrationUrl,
 			},
 			{
 				title: t((t) => t.home.risks.stores.title),
 				description: t((t) => t.home.risks.stores.description),
 				bullet: t((t) => t.home.risks.stores.bullet),
+				illustrationUrl: null,
 			},
 			{
 				title: t((t) => t.home.risks.handoff.title),
 				description: t((t) => t.home.risks.handoff.description),
 				bullet: t((t) => t.home.risks.handoff.bullet),
-			},
-		],
-		offerTracks: [
-			{
-				label: t((t) => t.home.offerTracks.migration.label),
-				title: t((t) => t.home.offerTracks.migration.title),
-				description: t((t) => t.home.offerTracks.migration.description),
-				bullets: [
-					t((t) => t.home.offerTracks.migration.bullets.item1),
-					t((t) => t.home.offerTracks.migration.bullets.item2),
-					t((t) => t.home.offerTracks.migration.bullets.item3),
-				],
-				illustrationUrl: assets.legacyServiceIllustrationUrl,
-			},
-			{
-				label: t((t) => t.home.offerTracks.workflow.label),
-				title: t((t) => t.home.offerTracks.workflow.title),
-				description: t((t) => t.home.offerTracks.workflow.description),
-				bullets: [
-					t((t) => t.home.offerTracks.workflow.bullets.item1),
-					t((t) => t.home.offerTracks.workflow.bullets.item2),
-					t((t) => t.home.offerTracks.workflow.bullets.item3),
-				],
-				illustrationUrl: assets.workflowServiceIllustrationUrl,
+				illustrationUrl: null,
 			},
 		],
 		migrationPhases: [

--- a/src/components/blocks/home/types.ts
+++ b/src/components/blocks/home/types.ts
@@ -5,7 +5,6 @@ export type HomeAssets = {
 	heroPhotoUrl: string | null;
 	legacyServiceIllustrationUrl: string | null;
 	proofIllustrationUrl: string | null;
-	risksIllustrationUrl: string | null;
 	workflowServiceIllustrationUrl: string | null;
 };
 
@@ -18,6 +17,7 @@ export type RiskCard = {
 	title: string;
 	description: string;
 	bullet: string;
+	illustrationUrl: string | null;
 };
 
 export type MigrationPhase = {
@@ -46,14 +46,6 @@ export type MigrationProgressItem = {
 	icon: LucideIcon;
 	step?: string;
 	outcome?: string;
-};
-
-export type OfferTrack = {
-	label: string;
-	title: string;
-	description: string;
-	bullets: string[];
-	illustrationUrl: string | null;
 };
 
 export type HomeContent = {
@@ -89,7 +81,6 @@ export type HomeContent = {
 	};
 	testimonials: Testimonial[];
 	riskCards: RiskCard[];
-	offerTracks: OfferTrack[];
 	migrationPhases: MigrationPhase[];
 	migrationStart: MigrationGate;
 	migrationEnd: MigrationGate;

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -4,7 +4,6 @@ export const HERO_PHOTO_ASSET_ID = "d891253f-cd33-486e-bff4-393d96d57f49";
 
 export const SITE_ILLUSTRATION_ASSET_IDS = {
 	hero: "9b2f6031-03ae-4d82-95a6-7ff111bf4fa2",
-	risks: "9ed8bab5-f579-4edb-a4e1-e106e799a605",
 	proof: "9e6052c6-4654-4db5-94dc-d21dccae8b43",
 	legacyService: "568d2276-c8f5-4e77-be40-2f07b0f3b787",
 	workflowService: "0e74f678-9442-4682-b767-347db8a2ec21",

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -276,30 +276,6 @@ export const en = {
 					"The migration ends with a workflow your team can operate without me.",
 			},
 		},
-		offerTracks: {
-			migration: {
-				label: "Track 01",
-				title: "Legacy React Native -> Expo",
-				description:
-					"I audit the native surface, upgrade React Native and Expo, then replace or isolate the modules that can block the migration.",
-				bullets: {
-					item1: "Native dependency map and replacement plan",
-					item2: "RN/Expo upgrade path with store constraints",
-					item3: "Release-safe migration roadmap for the team",
-				},
-			},
-			workflow: {
-				label: "Track 02",
-				title: "EAS workflow and releases",
-				description:
-					"I turn Expo deployments into a controlled path: QA updates, native builds, versioning, hotfixes, and handoff.",
-				bullets: {
-					item1: "EAS Build, Submit, Update, and QA channels",
-					item2: "Versioning, fingerprints, and rollback rules",
-					item3: "Documented QA to production playbook",
-				},
-			},
-		},
 		method: {
 			label: "Migration method",
 			title: "From your current app to an Expo release",

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -283,30 +283,6 @@ export const fr: Translations = {
 					"La migration se termine avec un workflow que votre équipe peut opérer sans moi.",
 			},
 		},
-		offerTracks: {
-			migration: {
-				label: "Chantier 01",
-				title: "React Native legacy vers Expo",
-				description:
-					"J'audite la surface native, je mets à niveau React Native et Expo, puis je remplace ou j'isole les modules qui peuvent bloquer la migration.",
-				bullets: {
-					item1: "Cartographie des dépendances natives et plan de remplacement",
-					item2: "Chemin RN/Expo avec contraintes stores intégrées",
-					item3: "Roadmap de migration livrable pour l'équipe",
-				},
-			},
-			workflow: {
-				label: "Chantier 02",
-				title: "Workflow EAS et releases",
-				description:
-					"Je transforme vos déploiements Expo en chemin maîtrisé : QA, builds natifs, versioning, hotfix et passation.",
-				bullets: {
-					item1: "EAS Build, Submit, Update et canaux QA",
-					item2: "Versioning, fingerprints et règles de rollback",
-					item3: "Guide QA vers production documenté",
-				},
-			},
-		},
 		method: {
 			label: "Méthode migration",
 			title: "De votre app actuelle à une release Expo",

--- a/src/routes/{-$locale}/index.tsx
+++ b/src/routes/{-$locale}/index.tsx
@@ -20,7 +20,6 @@ export const Route = createFileRoute("/{-$locale}/")({
 		const [
 			heroPhotoUrl,
 			heroIllustrationUrl,
-			risksIllustrationUrl,
 			proofIllustrationUrl,
 			legacyServiceIllustrationUrl,
 			workflowServiceIllustrationUrl,
@@ -33,16 +32,6 @@ export const Route = createFileRoute("/{-$locale}/")({
 					assetId: SITE_ILLUSTRATION_ASSET_IDS.hero,
 					width: 960,
 					height: 640,
-					fit: "cover",
-					format: "webp",
-					quality: 82,
-				},
-			}),
-			directus.getAssetUrl({
-				data: {
-					assetId: SITE_ILLUSTRATION_ASSET_IDS.risks,
-					width: 800,
-					height: 600,
 					fit: "cover",
 					format: "webp",
 					quality: 82,
@@ -85,7 +74,6 @@ export const Route = createFileRoute("/{-$locale}/")({
 			legacyServiceIllustrationUrl,
 			locale,
 			proofIllustrationUrl,
-			risksIllustrationUrl,
 			workflowServiceIllustrationUrl,
 		};
 	},
@@ -111,7 +99,6 @@ function App() {
 		heroPhotoUrl,
 		legacyServiceIllustrationUrl,
 		proofIllustrationUrl,
-		risksIllustrationUrl,
 		workflowServiceIllustrationUrl,
 	} = Route.useLoaderData();
 
@@ -122,7 +109,6 @@ function App() {
 				heroPhotoUrl,
 				legacyServiceIllustrationUrl,
 				proofIllustrationUrl,
-				risksIllustrationUrl,
 				workflowServiceIllustrationUrl,
 			}}
 		/>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Résumé

Supprime les cartes **Chantier 01** et **Chantier 02** de la section « Ce que je sécurise pendant la migration Expo » et réutilise leurs illustrations dans les cartes de risques correspondantes.

## Changements

- Suppression des cartes `OfferTrackCard` (Chantier 01 / Chantier 02)
- Intégration de l'illustration legacy dans la carte **Surface native**
- Intégration de l'illustration workflow dans la carte **Déploiements EAS et QA**
- Simplification de la mise en page : grille 2×2 de cartes de risques (les deux premières avec image, les deux autres sans)
- Suppression de l'illustration latérale dédiée (`risksIllustrationUrl`) devenue inutile
- Nettoyage des traductions `offerTracks` (FR/EN) et du type `OfferTrack`

## Vérification

- `npm run check` passe (biome + tsc)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2415-3ec3-7cdc-8604-46241980eacc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2415-3ec3-7cdc-8604-46241980eacc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

