### PR TITLE
Supprimer le label eyebrow du hero

### DIFF
--- a/src/components/blocks/home/HomeSections.tsx
+++ b/src/components/blocks/home/HomeSections.tsx
@@ -31,7 +31,6 @@ export function HomeHeroSection({
 		<section className="terminal-hero">
 			<div className="relative mx-auto grid w-full max-w-6xl gap-10 px-6 py-20 md:py-28 lg:grid-cols-[1.1fr_0.9fr]">
 				<div className="space-y-8">
-					<p className="terminal-label terminal-boot-line">{content.eyebrow}</p>
 					<h1 className="terminal-heading terminal-boot-line terminal-cursor text-4xl md:text-6xl">
 						{content.title}
 					</h1>

--- a/src/components/blocks/home/content.ts
+++ b/src/components/blocks/home/content.ts
@@ -21,7 +21,6 @@ export function buildHomeContent(
 ): HomeContent {
 	return {
 		hero: {
-			eyebrow: t((t) => t.home.hero.eyebrow),
 			title: t((t) => t.home.hero.title),
 			intro: t((t) => t.home.hero.intro),
 			ctaPrimary: t((t) => t.home.hero.ctaPrimary),

--- a/src/components/blocks/home/types.ts
+++ b/src/components/blocks/home/types.ts
@@ -51,7 +51,6 @@ export type MigrationProgressItem = {
 
 export type HomeContent = {
 	hero: {
-		eyebrow: string;
 		title: string;
 		intro: string;
 		ctaPrimary: string;

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -190,7 +190,6 @@ export const en = {
 	},
 	home: {
 		hero: {
-			eyebrow: "For React Native CTOs and lead techs",
 			title: "React Native to Expo migration.",
 			intro:
 				"I help your team migrate to Expo/EAS without blocking releases or losing ownership.",

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -197,7 +197,6 @@ export const fr: Translations = {
 	},
 	home: {
 		hero: {
-			eyebrow: "Pour CTO et lead tech React Native",
 			title: "Migration React Native vers Expo.",
 			intro:
 				"J'aide votre équipe à migrer vers Expo/EAS sans bloquer les releases ni perdre la main.",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Supprime le label « Pour CTO et lead tech React Native » au-dessus du titre principal sur la page d'accueil. Ce texte d'accroche faisait artificiel ; le hero commence désormais directement par le titre.

## Changements

- Retrait du `<p>` eyebrow dans `HomeSections.tsx`
- Nettoyage du type `HomeContent`, du builder de contenu et des traductions FR/EN

## Test plan

- [x] Build OK (`npm run build`)
- [ ] Vérifier visuellement que le hero démarre bien sur le titre sans espace vide gênant
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2463-cc61-7071-b281-cff1a4ded269"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2463-cc61-7071-b281-cff1a4ded269"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

