### PR TITLE
Refactor terminal CSS into Tailwind theme and shadcn primitives

### DIFF
--- a/components.json
+++ b/components.json
@@ -6,7 +6,7 @@
   "tailwind": {
     "config": "",
     "css": "src/styles.css",
-    "baseColor": "zinc",
+    "baseColor": "neutral",
     "cssVariables": true,
     "prefix": ""
   },

--- a/src/components/blocks/ConsentBanner.tsx
+++ b/src/components/blocks/ConsentBanner.tsx
@@ -1,6 +1,7 @@
 import { Link } from "@tanstack/react-router";
 import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
 import { ANALYTICS_CONSENT_EVENT, useAnalyticsConsent } from "@/lib/analytics";
 import { useI18n } from "@/lib/i18n/use-i18n";
 
@@ -52,16 +53,14 @@ export default function ConsentBanner({ enabled = true }: ConsentBannerProps) {
 
 	return (
 		<div className="fixed bottom-4 left-4 right-4 z-50 md:left-auto md:right-6 md:max-w-lg">
-			<div className="terminal-card p-6">
-				<h2 className="terminal-heading text-lg">
-					{t((t) => t.consent.title)}
-				</h2>
-				<p className="terminal-muted mt-2 text-sm">
+			<Card className="p-6">
+				<h2 className="text-heading text-lg">{t((t) => t.consent.title)}</h2>
+				<p className="text-body-muted mt-2 text-sm">
 					{t((t) => t.consent.description)}
 				</p>
 
 				{showDetails ? (
-					<div className="terminal-muted mt-4 space-y-4 text-sm">
+					<div className="text-body-muted mt-4 space-y-4 text-sm">
 						<div>
 							<p className="font-semibold text-foreground">
 								{t((t) => t.consent.essentialTitle)}
@@ -106,7 +105,7 @@ export default function ConsentBanner({ enabled = true }: ConsentBannerProps) {
 						{t((t) => t.consent.accept)}
 					</Button>
 				</div>
-			</div>
+			</Card>
 		</div>
 	);
 }

--- a/src/components/blocks/CvDocument.tsx
+++ b/src/components/blocks/CvDocument.tsx
@@ -30,8 +30,8 @@ export function CvDocument({
 	const { cv, experience, projects, education } = content;
 
 	return (
-		<div className="cv-page bg-[#f6f1ea] px-4 py-8 text-slate-900 md:px-6 md:py-10">
-			<article className="cv-sheet mx-auto w-full max-w-[210mm] rounded-2xl border border-slate-200 bg-white p-6 shadow-sm md:p-10">
+		<div className="bg-[#f6f1ea] px-4 py-8 text-slate-900 print:bg-white print:p-0 md:px-6 md:py-10">
+			<article className="mx-auto w-full max-w-[210mm] rounded-2xl border border-slate-200 bg-white p-6 shadow-sm print:m-0 print:min-h-[297mm] print:w-[210mm] print:max-w-[210mm] print:rounded-none print:border-0 print:p-0 print:shadow-none md:p-10">
 				<CvHeader cv={cv} heroPhotoUrl={heroPhotoUrl} />
 
 				<CvSection title={cv.sections.experience}>
@@ -41,9 +41,12 @@ export function CvDocument({
 							title={`${item.role} · ${item.company}`}
 							right={[item.period]}
 						>
-							<ul className="cv-detail-list mt-2 grid gap-1 pl-4 text-sm text-slate-700">
+							<ul className="mt-2 grid gap-1 pl-4 text-sm text-slate-700 print:mt-[0.3rem] print:gap-[0.1rem] print:pl-[0.9rem]">
 								{item.bullets.map((bullet) => (
-									<li key={bullet} className="list-disc">
+									<li
+										key={bullet}
+										className="list-disc print:text-[11.5px] print:leading-[1.2]"
+									>
 										{bullet}
 									</li>
 								))}
@@ -59,12 +62,15 @@ export function CvDocument({
 							title={project.name}
 							right={project.stack.split(",").map((tech) => tech.trim())}
 						>
-							<p className="cv-detail-text mt-2 text-sm text-slate-700">
+							<p className="mt-2 text-sm text-slate-700 print:mt-0 print:text-xs print:leading-[1.25]">
 								{project.context}
 							</p>
-							<ul className="cv-detail-list mt-2 grid gap-1 pl-4 text-sm text-slate-700">
+							<ul className="mt-2 grid gap-1 pl-4 text-sm text-slate-700 print:mt-[0.3rem] print:gap-[0.1rem] print:pl-[0.9rem]">
 								{project.highlights.map((highlight) => (
-									<li key={highlight} className="list-disc">
+									<li
+										key={highlight}
+										className="list-disc print:text-[11.5px] print:leading-[1.2]"
+									>
 										{highlight}
 									</li>
 								))}
@@ -80,10 +86,10 @@ export function CvDocument({
 							title={item.degree}
 							right={[item.period]}
 						>
-							<p className="cv-detail-text mt-1 text-sm text-slate-700">
+							<p className="mt-1 text-sm text-slate-700 print:text-xs print:leading-[1.25]">
 								{item.school}
 							</p>
-							<p className="cv-detail-text mt-1 text-sm text-slate-700">
+							<p className="mt-1 text-sm text-slate-700 print:text-xs print:leading-[1.25]">
 								{item.details}
 							</p>
 						</CvListItem>
@@ -102,8 +108,8 @@ function CvHeader({
 	heroPhotoUrl: string;
 }) {
 	return (
-		<header className="cv-avoid-break border-b border-slate-200 pb-6">
-			<div className="cv-header-grid grid gap-5 md:grid-cols-[1.45fr_0.75fr] md:items-start">
+		<header className="print:break-inside-avoid border-b border-slate-200 pb-6">
+			<div className="grid gap-5 print:grid-cols-[1.45fr_0.75fr] print:items-start md:grid-cols-[1.45fr_0.75fr] md:items-start">
 				<div>
 					<h1 className="text-3xl font-semibold tracking-tight text-slate-900">
 						{cv.header.name}
@@ -114,8 +120,8 @@ function CvHeader({
 						{cv.summary}
 					</p>
 				</div>
-				<div className="cv-header-aside cv-avoid-break mx-auto w-full max-w-[170px] md:justify-self-end">
-					<div className="cv-avatar mx-auto aspect-square w-[132px] overflow-hidden rounded-full border-4 border-teal-100 bg-amber-50 shadow-sm">
+				<div className="print:break-inside-avoid mx-auto w-full max-w-[170px] print:justify-self-end md:justify-self-end">
+					<div className="mx-auto aspect-square w-[132px] overflow-hidden rounded-full border-4 border-teal-100 bg-amber-50 shadow-sm print:overflow-hidden print:rounded-full print:shadow-none">
 						<img
 							src={heroPhotoUrl}
 							alt={cv.header.name}
@@ -123,7 +129,7 @@ function CvHeader({
 							loading="eager"
 						/>
 					</div>
-					<ul className="cv-contact-icons mt-4 flex flex-nowrap items-center justify-center gap-2 md:justify-end">
+					<ul className="mt-4 flex flex-nowrap items-center justify-center gap-2 print:justify-end md:justify-end">
 						<li>
 							<IconBadgeLink
 								href={`mailto:${cv.header.email}`}
@@ -167,8 +173,10 @@ function CvSection({
 	children: React.ReactNode;
 }) {
 	return (
-		<section className="cv-section mt-6">
-			<h2 className="cv-section-title">{title}</h2>
+		<section className="mt-6 print:mt-3">
+			<h2 className="text-[0.72rem] font-semibold uppercase tracking-[0.18em] text-slate-600">
+				{title}
+			</h2>
 			<div className="mt-3 grid gap-4">{children}</div>
 		</section>
 	);
@@ -190,7 +198,7 @@ function IconBadgeLink({
 			rel={href.startsWith("mailto:") ? undefined : "noreferrer"}
 			aria-label={label}
 			title={label}
-			className="cv-icon-badge inline-flex size-9 items-center justify-center rounded-full border border-slate-300 bg-white text-slate-700 shadow-sm transition hover:border-teal-300 hover:text-teal-700"
+			className="inline-flex size-9 items-center justify-center rounded-full border border-slate-300 bg-white text-slate-700 shadow-sm transition hover:border-teal-300 hover:text-teal-700 print:rounded-full print:shadow-none print:no-underline"
 		>
 			<span aria-hidden="true">{icon}</span>
 			<span className="sr-only">{label}</span>
@@ -216,7 +224,7 @@ function CvListItem({
 	children: React.ReactNode;
 }) {
 	return (
-		<article className="cv-list-item cv-avoid-break border-b border-slate-100 pb-4 last:border-b-0 last:pb-0">
+		<article className="print:break-inside-avoid border-b border-slate-100 pb-4 last:border-b-0 last:pb-0 print:pb-[0.45rem]">
 			<div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
 				<h3 className="text-sm font-semibold text-slate-900">{title}</h3>
 				{right && right.length > 0 ? (

--- a/src/components/blocks/Header.tsx
+++ b/src/components/blocks/Header.tsx
@@ -7,6 +7,7 @@ import {
 	HeaderMenuLink,
 } from "@/components/blocks/header-links";
 import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
 import {
 	NavigationMenu,
 	NavigationMenuContent,
@@ -85,11 +86,11 @@ export default function Header({ blogPosts = [] }: HeaderProps) {
 						<Link
 							to="/{-$locale}"
 							params={localeParams}
-							className="terminal-cursor truncate text-lg font-semibold tracking-tight text-foreground hover:text-secondary"
+							className="text-cursor truncate text-lg font-semibold tracking-tight text-foreground hover:text-secondary"
 						>
 							{t((t) => t.nav.brand)}
 						</Link>
-						<span className="terminal-label hidden md:inline">
+						<span className="text-kicker hidden md:inline">
 							{t((t) => t.nav.tagline)}
 						</span>
 					</div>
@@ -141,9 +142,7 @@ export default function Header({ blogPosts = [] }: HeaderProps) {
 									</NavigationMenuTrigger>
 									<NavigationMenuContent className="w-[calc(100vw-3rem)] max-w-[480px] p-4 md:w-[480px]">
 										<div className="flex items-center justify-between px-1 pb-2">
-											<p className="terminal-label">
-												{t((t) => t.blog.latest)}
-											</p>
+											<p className="text-kicker">{t((t) => t.blog.latest)}</p>
 											<Link
 												to="/{-$locale}/blog"
 												params={localeParams}
@@ -153,9 +152,9 @@ export default function Header({ blogPosts = [] }: HeaderProps) {
 											</Link>
 										</div>
 										{blogPreview.length === 0 ? (
-											<p className="terminal-card p-4 text-sm">
+											<Card showPin={false} className="p-4 text-sm">
 												{t((t) => t.blog.empty)}
-											</p>
+											</Card>
 										) : (
 											<ul className="grid gap-3 md:grid-cols-2">
 												{blogPreview.map((post) => (

--- a/src/components/blocks/HeroIntroCard.tsx
+++ b/src/components/blocks/HeroIntroCard.tsx
@@ -1,3 +1,4 @@
+import { Card } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 
 type HeroIntroCardProps = {
@@ -15,7 +16,7 @@ export function HeroIntroCard({
 }: HeroIntroCardProps) {
 	if (!heroPhotoUrl) {
 		return (
-			<p className={cn("terminal-muted text-lg md:text-xl", className)}>
+			<p className={cn("text-body-muted text-lg md:text-xl", className)}>
 				{intro}
 			</p>
 		);
@@ -28,18 +29,23 @@ export function HeroIntroCard({
 				className,
 			)}
 		>
-			<div className="terminal-image-frame inline-flex shrink-0 self-center p-2 sm:self-start">
-				<div className="size-20 shrink-0 overflow-hidden bg-muted md:size-24">
+			<div className="image-frame inline-flex shrink-0 self-center p-2 sm:self-start">
+				<span className="image-frame-overlay" aria-hidden="true" />
+				<div className="relative size-20 shrink-0 overflow-hidden bg-muted md:size-24">
 					<img
 						src={heroPhotoUrl}
 						alt={alt}
-						className="terminal-image h-full w-full object-cover"
+						className="image-treated h-full w-full object-cover"
 					/>
 				</div>
 			</div>
-			<p className="terminal-card terminal-card-light px-4 py-3 text-sm md:text-base">
+			<Card
+				variant="light"
+				showPin={false}
+				className="px-4 py-3 text-sm md:text-base"
+			>
 				{intro}
-			</p>
+			</Card>
 		</div>
 	);
 }

--- a/src/components/blocks/MarkdownContent.tsx
+++ b/src/components/blocks/MarkdownContent.tsx
@@ -10,12 +10,12 @@ export default function MarkdownContent({
 	return (
 		<div
 			className={
-				"terminal-prose prose prose-invert mx-auto w-full min-w-0 max-w-none break-words text-muted-foreground prose-headings:text-foreground " +
+				"font-mono prose prose-invert mx-auto w-full min-w-0 max-w-none break-words text-muted-foreground prose-headings:font-display prose-headings:text-foreground " +
 				"prose-p:leading-relaxed prose-a:text-secondary prose-a:font-semibold " +
 				"[& :not(pre)>code]:break-words [& :not(pre)>code]:whitespace-pre-wrap " +
-				"prose-pre:max-w-full prose-pre:overflow-x-auto prose-pre:whitespace-pre prose-pre:break-normal prose-pre:rounded-[var(--radius)] prose-pre:border-2 prose-pre:border-secondary prose-pre:bg-background prose-pre:shadow-[4px_4px_0_var(--terminal-shadow)] " +
+				"prose-pre:max-w-full prose-pre:overflow-x-auto prose-pre:whitespace-pre prose-pre:break-normal prose-pre:rounded-lg prose-pre:border-2 prose-pre:border-secondary prose-pre:bg-background prose-pre:shadow-hard-button " +
 				"[& pre code]:whitespace-pre [& pre code]:break-normal " +
-				"prose-img:rounded-[var(--radius)] prose-img:border-2 prose-img:border-secondary prose-img:shadow-[6px_6px_0_var(--terminal-shadow)] prose-img:object-cover " +
+				"prose-img:rounded-lg prose-img:border-2 prose-img:border-secondary prose-img:shadow-hard-md prose-img:object-cover " +
 				(className ? ` ${className}` : "")
 			}
 			dangerouslySetInnerHTML={{ __html: contentHtml }}

--- a/src/components/blocks/RootShell.tsx
+++ b/src/components/blocks/RootShell.tsx
@@ -21,9 +21,9 @@ export function RootShell({
 
 	return (
 		<>
-			<div className="min-h-screen flex flex-col">
+			<div className="flex min-h-screen flex-col">
 				<Header blogPosts={blogPreview} />
-				<main className="flex-1">{children}</main>
+				<main className="site-shell flex-1">{children}</main>
 				<SiteFooter />
 			</div>
 			{env.VITE_POSTHOG_KEY ? <ConsentBanner /> : null}

--- a/src/components/blocks/SiteFooter.tsx
+++ b/src/components/blocks/SiteFooter.tsx
@@ -25,11 +25,11 @@ export default function SiteFooter() {
 		<footer className="border-t-2 border-secondary/50 bg-background">
 			<div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-6 py-10 md:flex-row md:items-center md:justify-between">
 				<div className="space-y-2">
-					<p className="terminal-heading text-lg">{t((t) => t.nav.brand)}</p>
-					<p className="terminal-muted text-sm">
+					<p className="text-heading text-lg">{t((t) => t.nav.brand)}</p>
+					<p className="text-body-muted text-sm">
 						{t((t) => t.footer.description)}
 					</p>
-					<p className="terminal-label">&gt; schedule_call --slot available</p>
+					<p className="text-kicker">&gt; schedule_call --slot available</p>
 				</div>
 				<div className="flex flex-wrap items-center gap-4 text-sm text-muted-foreground">
 					<a

--- a/src/components/blocks/SiteIllustration.tsx
+++ b/src/components/blocks/SiteIllustration.tsx
@@ -1,35 +1,31 @@
 import { cn } from "@/lib/utils";
 
-type SiteIllustrationProps = {
-	src?: string | null;
-	alt?: string;
-	className?: string;
-	imageClassName?: string;
-	priority?: boolean;
-};
-
 export function SiteIllustration({
 	src,
 	alt = "",
 	className,
-	imageClassName,
 	priority = false,
-}: SiteIllustrationProps) {
-	if (!src) return null;
-
+}: {
+	src: string | null;
+	alt?: string;
+	className?: string;
+	priority?: boolean;
+}) {
 	return (
-		<div className={cn("terminal-image-frame group p-2", className)}>
-			<img
-				src={src}
-				alt={alt}
-				loading={priority ? "eager" : "lazy"}
-				decoding={priority ? "sync" : "async"}
-				fetchPriority={priority ? "high" : "auto"}
-				className={cn(
-					"terminal-image h-full w-full object-cover",
-					imageClassName,
-				)}
-			/>
+		<div className={cn("image-frame group p-2", className)}>
+			<span className="image-frame-overlay" aria-hidden="true" />
+			{src ? (
+				<img
+					src={src}
+					alt={alt}
+					loading={priority ? "eager" : "lazy"}
+					className={cn(
+						"image-treated relative h-full w-full object-cover group-hover:scale-[1.025] group-hover:saturate-[0.95] group-hover:contrast-[1.28]",
+					)}
+				/>
+			) : (
+				<div className="relative h-full w-full bg-muted" aria-hidden="true" />
+			)}
 		</div>
 	);
 }

--- a/src/components/blocks/editorial.tsx
+++ b/src/components/blocks/editorial.tsx
@@ -1,5 +1,7 @@
 import { Link } from "@tanstack/react-router";
+import type React from "react";
 import { useEffect } from "react";
+import { Card, cardVariants } from "@/components/ui/card";
 import { ANALYTICS_EVENTS, useAnalytics } from "@/lib/analytics";
 import type { DocSummary, PostSummary } from "@/lib/directus";
 import { cn } from "@/lib/utils";
@@ -69,54 +71,54 @@ export function ArticleCardLink({
 		>
 			{variant === "featured" ? (
 				<div className="flex flex-col md:flex-row gap-8 md:items-center">
-					<div className="terminal-image-frame flex-1 aspect-[16/10]">
+					<div className="image-frame flex-1 aspect-[16/10]">
+						<span className="image-frame-overlay" aria-hidden="true" />
 						<ArticleImage
 							src={article.imageUrl}
 							alt={article.title}
-							className="terminal-image w-full h-full object-cover"
+							className="image-treated relative h-full w-full object-cover group-hover:scale-[1.025] group-hover:saturate-[0.95] group-hover:contrast-[1.28]"
 						/>
 					</div>
 					<div className="flex-1">
 						{featuredLabel ? (
-							<p className="terminal-label">{featuredLabel}</p>
+							<p className="text-kicker">{featuredLabel}</p>
 						) : null}
-						<h2 className="terminal-heading mt-3 text-3xl transition-colors group-hover:text-secondary md:text-4xl">
+						<h2 className="text-heading mt-3 text-3xl transition-colors group-hover:text-secondary md:text-4xl">
 							{article.title}
 						</h2>
-						<div className="terminal-label mt-4 text-sm">
+						<div className="text-kicker mt-4 text-sm">
 							{article.publishedAtLabel}
 						</div>
 					</div>
 				</div>
 			) : (
-				<div className="terminal-card overflow-hidden">
-					<div className="terminal-image-frame aspect-[16/10] border-0 shadow-none">
+				<Card showPin={false} className="overflow-hidden">
+					<div className="image-frame aspect-[16/10] border-0 shadow-none">
+						<span className="image-frame-overlay" aria-hidden="true" />
 						<ArticleImage
 							src={article.imageUrl}
 							alt={article.title}
-							className="terminal-image w-full h-full object-cover"
+							className="image-treated relative h-full w-full object-cover group-hover:scale-[1.025] group-hover:saturate-[0.95] group-hover:contrast-[1.28]"
 						/>
 					</div>
 					<div className={variant === "compact" ? "p-4 md:p-6" : "p-6"}>
 						<div
 							className={
-								variant === "compact"
-									? "terminal-label mb-2"
-									: "terminal-label mb-3"
+								variant === "compact" ? "text-kicker mb-2" : "text-kicker mb-3"
 							}
 						>
 							{article.publishedAtLabel}
 						</div>
 						<h4
 							className={cn(
-								"terminal-heading transition-colors group-hover:text-secondary line-clamp-2",
+								"text-heading transition-colors group-hover:text-secondary line-clamp-2",
 								variant === "compact" ? "text-base md:text-lg" : "text-lg",
 							)}
 						>
 							{article.title}
 						</h4>
 					</div>
-				</div>
+				</Card>
 			)}
 		</Link>
 	);
@@ -140,11 +142,11 @@ export function DocumentCardLink({
 		<Link
 			to="/{-$locale}/docs/$slug"
 			params={{ ...localeParams, slug: doc.slug }}
-			className={
-				isCompact
-					? "terminal-card p-6 text-sm transition hover:no-underline"
-					: "terminal-card p-8 transition hover:no-underline"
-			}
+			className={cn(
+				cardVariants(),
+				"transition hover:no-underline",
+				isCompact ? "p-6 text-sm" : "p-8",
+			)}
 			onClick={
 				isCompact
 					? undefined
@@ -161,9 +163,9 @@ export function DocumentCardLink({
 				doc.title
 			) : (
 				<>
-					<h2 className="terminal-heading pr-8 text-xl">{doc.title}</h2>
+					<h2 className="text-heading pr-8 text-xl">{doc.title}</h2>
 					{description ? (
-						<p className="terminal-muted mt-3 text-sm">{description}</p>
+						<p className="text-body-muted mt-3 text-sm">{description}</p>
 					) : null}
 				</>
 			)}
@@ -189,24 +191,24 @@ export function ContentHero({
 	descriptionClassName?: string;
 }) {
 	return (
-		<section className="terminal-hero">
+		<section className="section-hero">
 			<div
 				className={cn(
 					"relative mx-auto w-full px-6 py-20 text-center",
 					containerClassName,
 				)}
 			>
-				<p className="terminal-label terminal-boot-line">{label}</p>
+				<p className="text-kicker motion-safe:animate-boot-line">{label}</p>
 				<h1
 					className={cn(
-						"terminal-heading terminal-boot-line text-4xl md:text-5xl",
+						"text-heading motion-safe:animate-boot-line text-4xl md:text-5xl",
 						titleClassName,
 					)}
 				>
 					{title}
 				</h1>
 				{description ? (
-					<p className={cn("terminal-muted text-lg", descriptionClassName)}>
+					<p className={cn("text-body-muted text-lg", descriptionClassName)}>
 						{description}
 					</p>
 				) : null}
@@ -217,7 +219,11 @@ export function ContentHero({
 }
 
 export function ContentEmptyState({ children }: { children: React.ReactNode }) {
-	return <p className="terminal-card p-8 text-center">{children}</p>;
+	return (
+		<Card showPin={false} className="p-8 text-center">
+			{children}
+		</Card>
+	);
 }
 
 export function ContentErrorState({
@@ -242,18 +248,16 @@ export function ContentErrorState({
 	}, [captureException, error, source]);
 
 	return (
-		<div className="terminal-page">
-			<div
-				className={cn(
-					"py-24 px-6 max-w-5xl mx-auto text-center",
-					containerClassName,
-				)}
-			>
-				<h1 className="mb-3 text-2xl font-semibold text-destructive md:text-3xl">
-					{title}
-				</h1>
-				<p className="text-muted-foreground">{error.message || fallback}</p>
-			</div>
+		<div
+			className={cn(
+				"mx-auto max-w-5xl px-6 py-24 text-center",
+				containerClassName,
+			)}
+		>
+			<h1 className="mb-3 text-2xl font-semibold text-destructive md:text-3xl">
+				{title}
+			</h1>
+			<p className="text-muted-foreground">{error.message || fallback}</p>
 		</div>
 	);
 }

--- a/src/components/blocks/header-links.tsx
+++ b/src/components/blocks/header-links.tsx
@@ -1,5 +1,7 @@
 import { Link } from "@tanstack/react-router";
 import type React from "react";
+import { Badge } from "@/components/ui/badge";
+import { cardVariants } from "@/components/ui/card";
 import { NavigationMenuLink } from "@/components/ui/navigation-menu";
 import type { PostSummary } from "@/lib/directus";
 import type { Locale } from "@/lib/i18n/locale";
@@ -32,20 +34,21 @@ export function HeaderMenuLink({
 					params={params}
 					hash={hash}
 					className={cn(
-						"group terminal-card flex h-full flex-col gap-2 p-3 text-sm hover:no-underline",
+						cardVariants(),
+						"group flex h-full flex-col gap-2 p-3 text-sm hover:no-underline",
 						className,
 					)}
 				>
 					{icon ? (
 						<span className="flex items-center gap-3">
-							<span className="terminal-chip flex h-12 w-12 items-center justify-center p-0">
+							<Badge className="flex h-12 w-12 items-center justify-center p-0">
 								{icon}
-							</span>
+							</Badge>
 							<span className="flex min-h-12 flex-col justify-center">
 								<span className="text-sm font-semibold text-foreground group-hover:text-secondary">
 									{title}
 								</span>
-								<span className="terminal-muted text-xs line-clamp-2">
+								<span className="text-body-muted text-xs line-clamp-2">
 									{description}
 								</span>
 							</span>
@@ -55,7 +58,7 @@ export function HeaderMenuLink({
 							<span className="text-sm font-semibold text-foreground group-hover:text-secondary">
 								{title}
 							</span>
-							<span className="terminal-muted text-xs line-clamp-3">
+							<span className="text-body-muted text-xs line-clamp-3">
 								{description}
 							</span>
 						</>
@@ -96,7 +99,8 @@ export function HeaderMenuExternalLink({
 					rel="noreferrer"
 					onClick={onClick}
 					className={cn(
-						"group terminal-card flex h-full items-start gap-3 p-3 text-sm transition hover:no-underline",
+						cardVariants(),
+						"group flex h-full items-start gap-3 p-3 text-sm transition hover:no-underline",
 						isBrand
 							? "border-foreground bg-[#24292f] text-white hover:bg-[#1f2328]"
 							: "",
@@ -129,7 +133,7 @@ export function HeaderMenuExternalLink({
 						<span
 							className={cn(
 								"text-xs line-clamp-3",
-								isBrand ? "text-foreground/80" : "terminal-muted",
+								isBrand ? "text-foreground/80" : "text-body-muted",
 							)}
 						>
 							{description}
@@ -154,13 +158,17 @@ export function HeaderBlogPreviewLink({
 				<Link
 					to="/{-$locale}/blog/$slug"
 					params={{ ...localeParams, slug: post.slug }}
-					className="group terminal-card flex items-center gap-3 p-3 text-sm hover:no-underline"
+					className={cn(
+						cardVariants(),
+						"group flex items-center gap-3 p-3 text-sm hover:no-underline",
+					)}
 				>
-					<div className="terminal-image-frame h-14 w-20">
+					<div className="image-frame h-14 w-20">
+						<span className="image-frame-overlay" aria-hidden="true" />
 						<HeaderBlogPreviewImage src={post.imageUrl} alt={post.title} />
 					</div>
 					<div className="flex flex-col gap-1">
-						<span className="terminal-label text-[0.68rem]">
+						<span className="text-kicker text-[0.68rem]">
 							{post.publishedAtLabel}
 						</span>
 						<span className="text-sm font-semibold text-foreground group-hover:text-secondary line-clamp-2">
@@ -185,7 +193,7 @@ export function HeaderLocaleSwitcher({
 			<button
 				type="button"
 				onClick={() => onSwitchLocale("fr-FR")}
-				className={`rounded-[var(--radius)] border-2 px-2.5 py-1 text-xs font-semibold uppercase tracking-[0.16em] transition ${
+				className={`rounded-lg border-2 px-2.5 py-1 text-xs font-semibold uppercase tracking-[0.16em] transition ${
 					locale === "fr-FR"
 						? "border-secondary bg-secondary text-secondary-foreground"
 						: "border-secondary/60 bg-transparent text-secondary hover:border-accent hover:text-accent"
@@ -196,7 +204,7 @@ export function HeaderLocaleSwitcher({
 			<button
 				type="button"
 				onClick={() => onSwitchLocale("en-US")}
-				className={`rounded-[var(--radius)] border-2 px-2.5 py-1 text-xs font-semibold uppercase tracking-[0.16em] transition ${
+				className={`rounded-lg border-2 px-2.5 py-1 text-xs font-semibold uppercase tracking-[0.16em] transition ${
 					locale === "en-US"
 						? "border-secondary bg-secondary text-secondary-foreground"
 						: "border-secondary/60 bg-transparent text-secondary hover:border-accent hover:text-accent"
@@ -216,14 +224,16 @@ function HeaderBlogPreviewImage({
 	alt: string;
 }) {
 	if (!src) {
-		return <div className="h-full w-full bg-muted" aria-hidden="true" />;
+		return (
+			<div className="relative h-full w-full bg-muted" aria-hidden="true" />
+		);
 	}
 
 	return (
 		<img
 			src={src}
 			alt={alt}
-			className="terminal-image h-full w-full object-cover"
+			className="image-treated relative h-full w-full object-cover"
 		/>
 	);
 }

--- a/src/components/blocks/home/HomeCards.tsx
+++ b/src/components/blocks/home/HomeCards.tsx
@@ -1,15 +1,16 @@
 import { CheckCircle2, ShieldCheck } from "lucide-react";
 import { SiteIllustration } from "@/components/blocks/SiteIllustration";
+import { Card } from "@/components/ui/card";
 import type { RiskCard as RiskCardData } from "./types";
 
 const RiskCardBody = ({ risk }: { risk: RiskCardData }) => (
 	<>
 		<div className="flex items-center justify-between">
-			<h3 className="terminal-heading pr-8 text-lg">{risk.title}</h3>
+			<h3 className="text-heading pr-8 text-lg">{risk.title}</h3>
 			<ShieldCheck className="size-5 text-secondary" />
 		</div>
-		<p className="terminal-muted mt-3 text-sm">{risk.description}</p>
-		<p className="terminal-muted mt-5 flex items-start gap-2 text-sm">
+		<p className="text-body-muted mt-3 text-sm">{risk.description}</p>
+		<p className="text-body-muted mt-5 flex items-start gap-2 text-sm">
 			<CheckCircle2 className="mt-0.5 size-4 shrink-0 text-secondary" />
 			{risk.bullet}
 		</p>
@@ -25,8 +26,9 @@ export function RiskCard({
 }) {
 	if (risk.illustrationUrl) {
 		return (
-			<article
-				className="terminal-card grid overflow-hidden p-3 motion-safe:animate-fade-up md:grid-cols-[0.8fr_1fr]"
+			<Card
+				showPin={false}
+				className="grid overflow-hidden p-3 motion-safe:animate-fade-up md:grid-cols-[0.8fr_1fr]"
 				style={{ animationDelay: `${index * 120}ms` }}
 			>
 				<SiteIllustration
@@ -36,16 +38,16 @@ export function RiskCard({
 				<div className="flex flex-col p-3 pt-5 md:p-5">
 					<RiskCardBody risk={risk} />
 				</div>
-			</article>
+			</Card>
 		);
 	}
 
 	return (
-		<div
-			className="terminal-card p-6 motion-safe:animate-fade-up"
+		<Card
+			className="p-6 motion-safe:animate-fade-up"
 			style={{ animationDelay: `${index * 120}ms` }}
 		>
 			<RiskCardBody risk={risk} />
-		</div>
+		</Card>
 	);
 }

--- a/src/components/blocks/home/HomePage.tsx
+++ b/src/components/blocks/home/HomePage.tsx
@@ -30,7 +30,7 @@ export function HomePage({ assets }: { assets: HomeAssets }) {
 	useSectionViewTracking(sectionTracking, { pageType: "home", locale });
 
 	return (
-		<div className="terminal-page">
+		<>
 			<HomeHeroSection
 				assets={assets}
 				content={content.hero}
@@ -42,6 +42,6 @@ export function HomePage({ assets }: { assets: HomeAssets }) {
 			<HomeTestimonialsSection assets={assets} content={content} />
 			<HomeMethodSection content={content} />
 			<HomeFinalCta content={content.cta} capture={capture} />
-		</div>
+		</>
 	);
 }

--- a/src/components/blocks/home/HomeSections.tsx
+++ b/src/components/blocks/home/HomeSections.tsx
@@ -2,6 +2,7 @@ import { Link } from "@tanstack/react-router";
 import { Gauge, Rocket, ShieldCheck, Smartphone } from "lucide-react";
 import { HeroIntroCard } from "@/components/blocks/HeroIntroCard";
 import { SiteIllustration } from "@/components/blocks/SiteIllustration";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ANALYTICS_EVENTS, type useAnalytics } from "@/lib/analytics";
 import { SCHEDULE_VISIO_URL } from "@/lib/constants";
@@ -28,11 +29,13 @@ export function HomeHeroSection({
 	brandAlt: string;
 }) {
 	return (
-		<section className="terminal-hero">
+		<section className="section-hero">
 			<div className="relative mx-auto grid w-full max-w-6xl gap-10 px-6 py-20 md:py-28 lg:grid-cols-[1.1fr_0.9fr]">
 				<div className="space-y-8">
-					<p className="terminal-label terminal-boot-line">{content.eyebrow}</p>
-					<h1 className="terminal-heading terminal-boot-line terminal-cursor text-4xl md:text-6xl">
+					<p className="text-kicker motion-safe:animate-boot-line">
+						{content.eyebrow}
+					</p>
+					<h1 className="text-heading text-cursor motion-safe:animate-boot-line text-4xl md:text-6xl">
 						{content.title}
 					</h1>
 					<HeroIntroCard
@@ -76,18 +79,18 @@ export function HomeHeroSection({
 						</Button>
 					</div>
 					<div className="flex flex-wrap items-center gap-3 text-sm">
-						<div className="terminal-chip">
+						<Badge>
 							<Smartphone className="size-4" />
 							<span>{content.highlights.expertise}</span>
-						</div>
-						<div className="terminal-chip text-accent">
+						</Badge>
+						<Badge variant="accent">
 							<ShieldCheck className="size-4" />
 							<span>{content.highlights.delivery}</span>
-						</div>
-						<div className="terminal-chip text-foreground">
+						</Badge>
+						<Badge variant="foreground">
 							<Gauge className="size-4" />
 							<span>{content.highlights.performance}</span>
-						</div>
+						</Badge>
 					</div>
 				</div>
 				<div className="h-full">
@@ -111,16 +114,16 @@ export function HomeServicesSection({
 		// biome-ignore lint/correctness/useUniqueElementIds: anchor targets
 		<section
 			id="services"
-			className="terminal-section terminal-section-alt py-16 md:py-20"
+			className="section-divider section-muted py-16 md:py-20"
 		>
 			<div className="mx-auto w-full max-w-6xl px-6">
 				<div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
 					<div>
-						<h2 className="terminal-heading text-3xl md:text-4xl">
+						<h2 className="text-heading text-3xl md:text-4xl">
 							{content.servicesSection.title}
 						</h2>
 					</div>
-					<p className="terminal-muted max-w-xl">
+					<p className="text-body-muted max-w-xl">
 						{content.servicesSection.description}
 					</p>
 				</div>
@@ -143,15 +146,15 @@ export function HomeTestimonialsSection({
 }) {
 	return (
 		// biome-ignore lint/correctness/useUniqueElementIds: anchor targets
-		<section id="testimonials" className="terminal-section py-16 md:py-20">
+		<section id="testimonials" className="section-divider py-16 md:py-20">
 			<div className="mx-auto w-full max-w-6xl px-6">
 				<div className="grid gap-6 lg:grid-cols-[0.78fr_1.22fr] lg:items-end">
 					<div>
-						<h2 className="terminal-heading text-3xl md:text-4xl">
+						<h2 className="text-heading text-3xl md:text-4xl">
 							{content.testimonialsSection.title}
 						</h2>
 					</div>
-					<p className="terminal-muted lg:max-w-2xl">
+					<p className="text-body-muted lg:max-w-2xl">
 						{content.testimonialsSection.description}
 					</p>
 				</div>
@@ -186,16 +189,16 @@ export function HomeMethodSection({
 		// biome-ignore lint/correctness/useUniqueElementIds: anchor targets
 		<section
 			id="process"
-			className="terminal-section terminal-section-alt py-16 md:py-20"
+			className="section-divider section-muted py-16 md:py-20"
 		>
 			<div className="mx-auto w-full max-w-6xl px-6">
 				<div className="grid gap-6 lg:grid-cols-[0.86fr_1.14fr] lg:items-end">
 					<div>
-						<h2 className="terminal-heading text-3xl md:text-4xl">
+						<h2 className="text-heading text-3xl md:text-4xl">
 							{content.methodSection.title}
 						</h2>
 					</div>
-					<p className="terminal-muted lg:max-w-2xl">
+					<p className="text-body-muted lg:max-w-2xl">
 						{content.methodSection.description}
 					</p>
 				</div>
@@ -218,13 +221,11 @@ export function HomeFinalCta({
 	capture: AnalyticsCapture;
 }) {
 	return (
-		<section className="terminal-section terminal-section-alt py-16">
+		<section className="section-divider section-muted py-16">
 			<div className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-6 md:flex-row md:items-center md:justify-between">
 				<div>
-					<h2 className="terminal-heading text-3xl md:text-4xl">
-						{content.title}
-					</h2>
-					<p className="terminal-muted mt-3">{content.description}</p>
+					<h2 className="text-heading text-3xl md:text-4xl">{content.title}</h2>
+					<p className="text-body-muted mt-3">{content.description}</p>
 				</div>
 				<Button asChild size="lg">
 					<a

--- a/src/components/blocks/home/MigrationJourney.tsx
+++ b/src/components/blocks/home/MigrationJourney.tsx
@@ -1,5 +1,7 @@
 import { CheckCircle2 } from "lucide-react";
 import { type CSSProperties, useEffect, useMemo, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { cardVariants } from "@/components/ui/card";
 import { usePrefersReducedMotion } from "@/hooks/use-prefers-reduced-motion";
 import { cn } from "@/lib/utils";
 import type {
@@ -109,7 +111,8 @@ export function MigrationJourney({
 						<article
 							aria-current={status === "current" ? "step" : undefined}
 							className={cn(
-								"migration-progress-card terminal-card p-5 motion-safe:animate-fade-up",
+								cardVariants(),
+								"migration-progress-card p-5 motion-safe:animate-fade-up",
 								`migration-progress-card-${index + 1}`,
 							)}
 							data-state={status}
@@ -133,14 +136,14 @@ export function MigrationJourney({
 							</div>
 							<div className="mt-5 flex items-center gap-3">
 								{item.step ? (
-									<span className="terminal-chip flex h-9 w-12 items-center justify-center p-0">
+									<Badge className="flex h-9 w-12 items-center justify-center p-0">
 										{item.step}
-									</span>
+									</Badge>
 								) : null}
-								<p className="terminal-label">{item.label}</p>
+								<p className="text-kicker">{item.label}</p>
 							</div>
-							<h3 className="terminal-heading mt-3 text-xl">{item.title}</h3>
-							<p className="terminal-muted mt-3 text-sm">{item.description}</p>
+							<h3 className="text-heading mt-3 text-xl">{item.title}</h3>
+							<p className="text-body-muted mt-3 text-sm">{item.description}</p>
 							{"outcome" in item && item.outcome ? (
 								<p className="migration-progress-output mt-5">
 									<CheckCircle2 className="mt-0.5 size-4 shrink-0" />

--- a/src/components/blocks/home/TestimonialConsole.tsx
+++ b/src/components/blocks/home/TestimonialConsole.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { Card } from "@/components/ui/card";
 import { usePrefersReducedMotion } from "@/hooks/use-prefers-reduced-motion";
 import { cn } from "@/lib/utils";
 import type { Testimonial } from "./types";
@@ -58,9 +59,10 @@ export function TestimonialConsole({
 	]);
 
 	return (
-		<div
+		<Card
+			showPin={false}
 			className={cn(
-				"testimonial-console terminal-card mt-10 overflow-hidden p-0 motion-safe:animate-fade-up",
+				"testimonial-console mt-10 overflow-hidden p-0 motion-safe:animate-fade-up",
 				className,
 			)}
 		>
@@ -87,6 +89,6 @@ export function TestimonialConsole({
 					</blockquote>
 				</figure>
 			</div>
-		</div>
+		</Card>
 	);
 }

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,43 @@
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+	"inline-flex items-center gap-1.5 rounded-lg border-2 border-current px-2.5 py-1 text-xs leading-tight uppercase shadow-hard-sm",
+	{
+		variants: {
+			variant: {
+				default: "bg-card/85 text-secondary",
+				light: "bg-background text-secondary",
+				accent: "bg-card/85 text-accent",
+				foreground: "bg-card/85 text-foreground",
+			},
+		},
+		defaultVariants: {
+			variant: "default",
+		},
+	},
+);
+
+function Badge({
+	className,
+	variant = "default",
+	asChild = false,
+	...props
+}: React.ComponentProps<"span"> &
+	VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+	const Comp = asChild ? Slot : "span";
+
+	return (
+		<Comp
+			data-slot="badge"
+			data-variant={variant}
+			className={cn(badgeVariants({ variant }), className)}
+			{...props}
+		/>
+	);
+}
+
+export { Badge, badgeVariants };

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import type * as React from "react";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-	"inline-flex shrink-0 items-center justify-center gap-2 whitespace-nowrap rounded-[var(--radius)] border-2 border-current text-sm font-medium uppercase tracking-[0.08em] shadow-[4px_4px_0_var(--terminal-shadow)] outline-none transition-[color,background-color,box-shadow,transform] duration-150 ease-linear hover:translate-x-0.5 hover:translate-y-0.5 hover:shadow-[2px_2px_0_var(--terminal-shadow)] active:translate-x-1 active:translate-y-1 active:shadow-none disabled:pointer-events-none disabled:opacity-50 focus-visible:ring-[3px] focus-visible:ring-ring/60 aria-invalid:border-destructive aria-invalid:ring-destructive/20 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+	"inline-flex shrink-0 items-center justify-center gap-2 whitespace-nowrap rounded-lg border-2 border-current text-sm font-medium uppercase tracking-[0.08em] shadow-hard-button outline-none transition-[color,background-color,box-shadow,transform] duration-150 ease-linear hover:translate-x-0.5 hover:translate-y-0.5 hover:shadow-[2px_2px_0_var(--shadow-hard)] active:translate-x-1 active:translate-y-1 active:shadow-none disabled:pointer-events-none disabled:opacity-50 focus-visible:ring-[3px] focus-visible:ring-ring/60 aria-invalid:border-destructive aria-invalid:ring-destructive/20 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
 	{
 		variants: {
 			variant: {

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,117 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const cardVariants = cva(
+	"group/card relative rounded-lg border-2 text-card-foreground shadow-hard-md transition-[transform,box-shadow,border-color,background-color] duration-150 ease-[steps(2,end)] hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-hard-lg focus-within:-translate-x-0.5 focus-within:-translate-y-0.5 focus-within:shadow-hard-lg",
+	{
+		variants: {
+			variant: {
+				default:
+					"border-secondary/60 bg-card/92 hover:border-secondary focus-within:border-secondary",
+				light:
+					"border-accent bg-foreground text-background hover:border-accent focus-within:border-accent",
+			},
+		},
+		defaultVariants: {
+			variant: "default",
+		},
+	},
+);
+
+const CardPin = () => (
+	<span
+		className="pointer-events-none absolute top-3.5 right-4 h-[0.9rem] w-[0.65rem] opacity-0 transition-opacity duration-150 ease-[steps(2,end)] group-hover/card:opacity-100 group-focus-within/card:opacity-100"
+		aria-hidden="true"
+	>
+		<span className="absolute top-[0.35rem] left-0 h-[0.16rem] w-[0.65rem] bg-accent" />
+		<span className="absolute top-[0.2rem] left-[0.45rem] size-[0.16rem] bg-accent" />
+		<span className="absolute top-[0.5rem] left-[0.45rem] size-[0.16rem] bg-accent" />
+	</span>
+);
+
+function Card({
+	className,
+	variant = "default",
+	showPin = true,
+	children,
+	...props
+}: React.ComponentProps<"div"> &
+	VariantProps<typeof cardVariants> & { showPin?: boolean }) {
+	return (
+		<div
+			data-slot="card"
+			data-variant={variant}
+			className={cn(cardVariants({ variant }), className)}
+			{...props}
+		>
+			{showPin ? <CardPin /> : null}
+			{children}
+		</div>
+	);
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+	return (
+		<div
+			data-slot="card-header"
+			className={cn("flex flex-col gap-1.5 p-6", className)}
+			{...props}
+		/>
+	);
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+	return (
+		<div
+			data-slot="card-title"
+			className={cn(
+				"text-foreground text-lg font-normal leading-[0.98] text-balance",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+	return (
+		<div
+			data-slot="card-description"
+			className={cn("text-muted-foreground text-sm leading-relaxed", className)}
+			{...props}
+		/>
+	);
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+	return (
+		<div
+			data-slot="card-content"
+			className={cn("p-6 pt-0", className)}
+			{...props}
+		/>
+	);
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+	return (
+		<div
+			data-slot="card-footer"
+			className={cn("flex items-center p-6 pt-0", className)}
+			{...props}
+		/>
+	);
+}
+
+export {
+	Card,
+	CardContent,
+	CardDescription,
+	CardFooter,
+	CardHeader,
+	CardPin,
+	CardTitle,
+	cardVariants,
+};

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -2,20 +2,18 @@ import type * as React from "react";
 
 import { cn } from "@/lib/utils";
 
+const inputClassName =
+	"placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground border-secondary bg-input h-9 w-full min-w-0 rounded-lg border-2 px-3 py-1 text-base shadow-hard-sm transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/60 aria-invalid:border-destructive aria-invalid:ring-destructive/20";
+
 function Input({ className, type, ...props }: React.ComponentProps<"input">) {
 	return (
 		<input
 			type={type}
 			data-slot="input"
-			className={cn(
-				"file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-				"focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
-				"aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
-				className,
-			)}
+			className={cn(inputClassName, className)}
 			{...props}
 		/>
 	);
 }
 
-export { Input };
+export { Input, inputClassName };

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -13,7 +13,7 @@ function Label({
 		<LabelPrimitive.Root
 			data-slot="label"
 			className={cn(
-				"flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+				"flex items-center gap-2 text-sm leading-none font-medium text-foreground select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
 				className,
 			)}
 			{...props}

--- a/src/components/ui/navigation-menu.tsx
+++ b/src/components/ui/navigation-menu.tsx
@@ -59,7 +59,7 @@ function NavigationMenuItem({
 }
 
 const navigationMenuTriggerStyle = cva(
-	"group inline-flex h-9 w-max items-center justify-center rounded-[var(--radius)] border-2 border-transparent bg-transparent px-4 py-2 text-sm font-medium uppercase tracking-[0.08em] text-secondary outline-none transition-[color,background-color,border-color,box-shadow] duration-150 ease-linear hover:border-secondary hover:bg-muted hover:text-secondary focus:border-ring focus:bg-muted focus:text-secondary disabled:pointer-events-none disabled:opacity-50 data-[state=open]:border-secondary data-[state=open]:bg-muted data-[state=open]:text-secondary focus-visible:ring-[3px] focus-visible:ring-ring/60",
+	"group inline-flex h-9 w-max items-center justify-center rounded-lg border-2 border-transparent bg-transparent px-4 py-2 text-sm font-medium uppercase tracking-[0.08em] text-secondary outline-none transition-[color,background-color,border-color,box-shadow] duration-150 ease-linear hover:border-secondary hover:bg-muted hover:text-secondary focus:border-ring focus:bg-muted focus:text-secondary disabled:pointer-events-none disabled:opacity-50 data-[state=open]:border-secondary data-[state=open]:bg-muted data-[state=open]:text-secondary focus-visible:ring-[3px] focus-visible:ring-ring/60",
 );
 
 function NavigationMenuTrigger({
@@ -91,7 +91,7 @@ function NavigationMenuContent({
 			data-slot="navigation-menu-content"
 			className={cn(
 				"data-[motion^=from-]:animate-in data-[motion^=to-]:animate-out data-[motion^=from-]:fade-in data-[motion^=to-]:fade-out data-[motion=from-end]:slide-in-from-right-52 data-[motion=from-start]:slide-in-from-left-52 data-[motion=to-end]:slide-out-to-right-52 data-[motion=to-start]:slide-out-to-left-52 top-0 left-0 w-full p-2 pr-2.5 md:absolute md:w-auto",
-				"group-data-[viewport=false]/navigation-menu:bg-popover group-data-[viewport=false]/navigation-menu:text-popover-foreground group-data-[viewport=false]/navigation-menu:data-[state=open]:animate-in group-data-[viewport=false]/navigation-menu:data-[state=closed]:animate-out group-data-[viewport=false]/navigation-menu:data-[state=closed]:zoom-out-95 group-data-[viewport=false]/navigation-menu:data-[state=open]:zoom-in-95 group-data-[viewport=false]/navigation-menu:data-[state=open]:fade-in-0 group-data-[viewport=false]/navigation-menu:data-[state=closed]:fade-out-0 group-data-[viewport=false]/navigation-menu:top-full group-data-[viewport=false]/navigation-menu:mt-1.5 group-data-[viewport=false]/navigation-menu:overflow-hidden group-data-[viewport=false]/navigation-menu:rounded-[var(--radius)] group-data-[viewport=false]/navigation-menu:border-2 group-data-[viewport=false]/navigation-menu:border-secondary group-data-[viewport=false]/navigation-menu:shadow-[6px_6px_0_var(--terminal-shadow)] group-data-[viewport=false]/navigation-menu:duration-200 **:data-[slot=navigation-menu-link]:focus:ring-0 **:data-[slot=navigation-menu-link]:focus:outline-none",
+				"group-data-[viewport=false]/navigation-menu:bg-popover group-data-[viewport=false]/navigation-menu:text-popover-foreground group-data-[viewport=false]/navigation-menu:data-[state=open]:animate-in group-data-[viewport=false]/navigation-menu:data-[state=closed]:animate-out group-data-[viewport=false]/navigation-menu:data-[state=closed]:zoom-out-95 group-data-[viewport=false]/navigation-menu:data-[state=open]:zoom-in-95 group-data-[viewport=false]/navigation-menu:data-[state=open]:fade-in-0 group-data-[viewport=false]/navigation-menu:data-[state=closed]:fade-out-0 group-data-[viewport=false]/navigation-menu:top-full group-data-[viewport=false]/navigation-menu:mt-1.5 group-data-[viewport=false]/navigation-menu:overflow-hidden group-data-[viewport=false]/navigation-menu:rounded-lg group-data-[viewport=false]/navigation-menu:border-2 group-data-[viewport=false]/navigation-menu:border-secondary group-data-[viewport=false]/navigation-menu:shadow-hard-md group-data-[viewport=false]/navigation-menu:duration-200 **:data-[slot=navigation-menu-link]:focus:ring-0 **:data-[slot=navigation-menu-link]:focus:outline-none",
 				className,
 			)}
 			{...props}
@@ -112,7 +112,7 @@ function NavigationMenuViewport({
 			<NavigationMenuPrimitive.Viewport
 				data-slot="navigation-menu-viewport"
 				className={cn(
-					"origin-top-center relative mt-1.5 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-[var(--radius)] border-2 border-secondary bg-popover text-popover-foreground shadow-[6px_6px_0_var(--terminal-shadow)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 md:w-[var(--radix-navigation-menu-viewport-width)]",
+					"origin-top-center relative mt-1.5 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-lg border-2 border-secondary bg-popover text-popover-foreground shadow-hard-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 md:w-[var(--radix-navigation-menu-viewport-width)]",
 					className,
 				)}
 				{...props}
@@ -129,7 +129,7 @@ function NavigationMenuLink({
 		<NavigationMenuPrimitive.Link
 			data-slot="navigation-menu-link"
 			className={cn(
-				"flex flex-col gap-1 rounded-[var(--radius)] border-2 border-transparent p-2 text-sm text-muted-foreground outline-none transition-all duration-150 ease-linear hover:border-secondary hover:bg-muted hover:text-secondary focus:border-ring focus:bg-muted focus:text-secondary focus-visible:ring-[3px] focus-visible:ring-ring/60 data-[active=true]:border-secondary data-[active=true]:bg-muted data-[active=true]:text-secondary [&_svg:not([class*='text-'])]:text-muted-foreground [&_svg:not([class*='size-'])]:size-4",
+				"flex flex-col gap-1 rounded-lg border-2 border-transparent p-2 text-sm text-muted-foreground outline-none transition-all duration-150 ease-linear hover:border-secondary hover:bg-muted hover:text-secondary focus:border-ring focus:bg-muted focus:text-secondary focus-visible:ring-[3px] focus-visible:ring-ring/60 data-[active=true]:border-secondary data-[active=true]:bg-muted data-[active=true]:text-secondary [&_svg:not([class*='text-'])]:text-muted-foreground [&_svg:not([class*='size-'])]:size-4",
 				className,
 			)}
 			{...props}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -35,7 +35,7 @@ function SelectTrigger({
 			data-slot="select-trigger"
 			data-size={size}
 			className={cn(
-				"border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+				"border-secondary data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/60 aria-invalid:ring-destructive/20 aria-invalid:border-destructive flex h-9 w-fit items-center justify-between gap-2 rounded-lg border-2 bg-input px-3 py-2 text-sm whitespace-nowrap shadow-hard-sm transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
 				className,
 			)}
 			{...props}
@@ -60,7 +60,7 @@ function SelectContent({
 			<SelectPrimitive.Content
 				data-slot="select-content"
 				className={cn(
-					"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
+					"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg border-2 border-secondary shadow-hard-md",
 					position === "popper" &&
 						"data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
 					className,

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -17,7 +17,7 @@ function Separator({
 			decorative={decorative}
 			orientation={orientation}
 			className={cn(
-				"bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px",
+				"shrink-0 bg-secondary/25 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px",
 				className,
 			)}
 			{...props}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -56,7 +56,7 @@ function SheetContent({
 			<SheetPrimitive.Content
 				data-slot="sheet-content"
 				className={cn(
-					"bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+					"bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 border-2 border-secondary shadow-hard-md transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
 					side === "right" &&
 						"data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
 					side === "left" &&

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -472,7 +472,7 @@ const sidebarMenuButtonVariants = cva(
 			variant: {
 				default: "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
 				outline:
-					"bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]",
+					"bg-background shadow-[0_0_0_1px_var(--sidebar-border)] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_var(--sidebar-accent)]",
 			},
 			size: {
 				default: "h-8 text-sm",

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -5,7 +5,7 @@ function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
 		<div
 			data-slot="skeleton"
 			className={cn(
-				"animate-pulse rounded-[var(--radius)] border-2 border-secondary/50 bg-muted",
+				"animate-pulse rounded-lg border-2 border-secondary/50 bg-muted",
 				className,
 			)}
 			{...props}

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -39,7 +39,7 @@ function Slider({
 			<SliderPrimitive.Track
 				data-slot="slider-track"
 				className={cn(
-					"bg-muted relative grow overflow-hidden rounded-full data-[orientation=horizontal]:h-1.5 data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-1.5",
+					"bg-muted relative grow overflow-hidden rounded-full border-2 border-secondary/40 data-[orientation=horizontal]:h-2 data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-2",
 				)}
 			>
 				<SliderPrimitive.Range
@@ -53,7 +53,7 @@ function Slider({
 				<SliderPrimitive.Thumb
 					data-slot="slider-thumb"
 					key={index}
-					className="border-primary ring-ring/50 block size-4 shrink-0 rounded-full border bg-white shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
+					className="border-secondary ring-ring/50 block size-4 shrink-0 rounded-lg border-2 bg-background shadow-hard-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
 				/>
 			))}
 		</SliderPrimitive.Root>

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -11,7 +11,7 @@ function Switch({
 		<SwitchPrimitive.Root
 			data-slot="switch"
 			className={cn(
-				"peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+				"peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/60 inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border-2 border-secondary shadow-hard-sm transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
 				className,
 			)}
 			{...props}
@@ -19,7 +19,7 @@ function Switch({
 			<SwitchPrimitive.Thumb
 				data-slot="switch-thumb"
 				className={cn(
-					"bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0",
+					"bg-background data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0",
 				)}
 			/>
 		</SwitchPrimitive.Root>

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -7,7 +7,7 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
 		<textarea
 			data-slot="textarea"
 			className={cn(
-				"border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+				"placeholder:text-muted-foreground border-secondary bg-input flex field-sizing-content min-h-16 w-full rounded-lg border-2 px-3 py-2 text-base shadow-hard-sm transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/60 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm aria-invalid:border-destructive aria-invalid:ring-destructive/20",
 				className,
 			)}
 			{...props}

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -46,13 +46,13 @@ function TooltipContent({
 				data-slot="tooltip-content"
 				sideOffset={sideOffset}
 				className={cn(
-					"bg-foreground text-background animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
+					"bg-popover text-popover-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-lg border-2 border-secondary px-3 py-1.5 text-xs text-balance shadow-hard-sm",
 					className,
 				)}
 				{...props}
 			>
 				{children}
-				<TooltipPrimitive.Arrow className="bg-foreground fill-foreground z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+				<TooltipPrimitive.Arrow className="bg-popover fill-popover z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
 			</TooltipPrimitive.Content>
 		</TooltipPrimitive.Portal>
 	);

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -75,13 +75,13 @@ const Char123LocaleChar125BlogSlugRoute =
 export interface FileRoutesByFullPath {
   '/sitemap.xml': typeof SitemapDotxmlRoute
   '/{-$locale}/cv': typeof Char123LocaleChar125CvRoute
-  '/{-$locale}': typeof Char123LocaleChar125IndexRoute
+  '/{-$locale}/': typeof Char123LocaleChar125IndexRoute
   '/{-$locale}/blog/$slug': typeof Char123LocaleChar125BlogSlugRoute
   '/{-$locale}/docs/$slug': typeof Char123LocaleChar125DocsSlugRoute
   '/{-$locale}/docs/mentions-legales': typeof Char123LocaleChar125DocsMentionsLegalesRoute
   '/{-$locale}/docs/politique-confidentialite': typeof Char123LocaleChar125DocsPolitiqueConfidentialiteRoute
-  '/{-$locale}/blog': typeof Char123LocaleChar125BlogIndexRoute
-  '/{-$locale}/docs': typeof Char123LocaleChar125DocsIndexRoute
+  '/{-$locale}/blog/': typeof Char123LocaleChar125BlogIndexRoute
+  '/{-$locale}/docs/': typeof Char123LocaleChar125DocsIndexRoute
 }
 export interface FileRoutesByTo {
   '/sitemap.xml': typeof SitemapDotxmlRoute
@@ -111,13 +111,13 @@ export interface FileRouteTypes {
   fullPaths:
     | '/sitemap.xml'
     | '/{-$locale}/cv'
-    | '/{-$locale}'
+    | '/{-$locale}/'
     | '/{-$locale}/blog/$slug'
     | '/{-$locale}/docs/$slug'
     | '/{-$locale}/docs/mentions-legales'
     | '/{-$locale}/docs/politique-confidentialite'
-    | '/{-$locale}/blog'
-    | '/{-$locale}/docs'
+    | '/{-$locale}/blog/'
+    | '/{-$locale}/docs/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/sitemap.xml'
@@ -166,7 +166,7 @@ declare module '@tanstack/react-router' {
     '/{-$locale}/': {
       id: '/{-$locale}/'
       path: '/{-$locale}'
-      fullPath: '/{-$locale}'
+      fullPath: '/{-$locale}/'
       preLoaderRoute: typeof Char123LocaleChar125IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
@@ -180,14 +180,14 @@ declare module '@tanstack/react-router' {
     '/{-$locale}/docs/': {
       id: '/{-$locale}/docs/'
       path: '/{-$locale}/docs'
-      fullPath: '/{-$locale}/docs'
+      fullPath: '/{-$locale}/docs/'
       preLoaderRoute: typeof Char123LocaleChar125DocsIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/{-$locale}/blog/': {
       id: '/{-$locale}/blog/'
       path: '/{-$locale}/blog'
-      fullPath: '/{-$locale}/blog'
+      fullPath: '/{-$locale}/blog/'
       preLoaderRoute: typeof Char123LocaleChar125BlogIndexRouteImport
       parentRoute: typeof rootRouteImport
     }

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -170,13 +170,13 @@ function NotFound() {
 	const { t, localeParam } = useI18n();
 
 	return (
-		<div className="terminal-page flex min-h-[calc(100vh-8rem)] flex-col items-center justify-center px-6">
+		<div className="flex min-h-[calc(100vh-8rem)] flex-col items-center justify-center px-6">
 			<div className="max-w-md space-y-6 text-center">
-				<p className="terminal-label">{t((t) => t.notFound.label)}</p>
-				<h1 className="terminal-heading text-5xl md:text-6xl">
+				<p className="text-kicker">{t((t) => t.notFound.label)}</p>
+				<h1 className="text-heading text-5xl md:text-6xl">
 					{t((t) => t.notFound.title)}
 				</h1>
-				<p className="terminal-muted">{t((t) => t.notFound.description)}</p>
+				<p className="text-body-muted">{t((t) => t.notFound.description)}</p>
 				<Button asChild>
 					<Link to="/{-$locale}" params={{ locale: localeParam }}>
 						{t((t) => t.notFound.backHome)}

--- a/src/routes/{-$locale}/blog/$slug.tsx
+++ b/src/routes/{-$locale}/blog/$slug.tsx
@@ -9,6 +9,7 @@ import {
 import { HeroIntroCard } from "@/components/blocks/HeroIntroCard";
 import MarkdownContent from "@/components/blocks/MarkdownContent";
 import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
 	ANALYTICS_EVENTS,
@@ -89,16 +90,14 @@ export const Route = createFileRoute("/{-$locale}/blog/$slug")({
 		});
 	},
 	pendingComponent: () => (
-		<div className="terminal-page">
-			<div className="mx-auto w-full max-w-4xl">
-				<div className="flex flex-col gap-8 px-6 py-16">
-					<Skeleton className="h-10 w-3/4 mx-auto" />
-					<Skeleton className="w-full aspect-video" />
-					<div className="space-y-4">
-						<Skeleton className="h-4 w-full" />
-						<Skeleton className="h-4 w-full" />
-						<Skeleton className="h-4 w-3/4" />
-					</div>
+		<div className="mx-auto w-full max-w-4xl">
+			<div className="flex flex-col gap-8 px-6 py-16">
+				<Skeleton className="h-10 w-3/4 mx-auto" />
+				<Skeleton className="w-full aspect-video" />
+				<div className="space-y-4">
+					<Skeleton className="h-4 w-full" />
+					<Skeleton className="h-4 w-full" />
+					<Skeleton className="h-4 w-3/4" />
 				</div>
 			</div>
 		</div>
@@ -125,75 +124,74 @@ function BlogDetailPage() {
 	});
 
 	return (
-		<div className="terminal-page">
-			<article className="mx-auto w-full max-w-4xl">
-				<div className="flex flex-col gap-8 px-6 py-16">
-					<Link
-						to="/{-$locale}/blog"
-						params={localeParams}
-						className="terminal-label hover:text-secondary"
-					>
-						{t((t) => t.blog.back)}
-					</Link>
-					<h1 className="terminal-heading text-center text-3xl md:text-5xl">
-						{displayTitle}
-					</h1>
-					<p className="terminal-label text-center text-sm">
-						{post.publishedAtLabel}
-					</p>
-					<div className="terminal-image-frame w-full aspect-video">
-						<ArticleImage
-							src={post.imageUrl}
-							alt={displayTitle}
-							className="terminal-image w-full h-full object-cover"
-						/>
-					</div>
-					<MarkdownContent contentHtml={contentHtml} />
-					{seoOverride ? <SeoInsightSection override={seoOverride} /> : null}
-					<div className="mt-16 space-y-4">
-						<HeroIntroCard
-							heroPhotoUrl={heroPhotoUrl}
-							intro={t((t) => t.home.hero.intro)}
-							alt={t((t) => t.nav.brand)}
-						/>
-						<Button asChild>
-							<a
-								href={SCHEDULE_VISIO_URL}
-								target="_blank"
-								rel="noreferrer"
-								onClick={() =>
-									capture(ANALYTICS_EVENTS.ctaClick, {
-										cta: "schedule_call",
-										placement: "blog_post",
-										href: SCHEDULE_VISIO_URL,
-									})
-								}
-							>
-								{t((t) => t.blog.bookCtaButton)}
-								<ArrowUpRight className="size-4" />
-							</a>
-						</Button>
-					</div>
-
-					{suggestedArticles.length > 0 ? (
-						<div className="terminal-divider mt-16 border-t pt-16">
-							<h3 className="terminal-heading mb-8 text-center text-2xl">
-								{t((t) => t.blog.other)}
-							</h3>
-							<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-8">
-								{suggestedArticles.map((article) => (
-									<SuggestedArticleCard
-										key={article.slug}
-										article={article}
-										localeParams={localeParams}
-									/>
-								))}
-							</div>
-						</div>
-					) : null}
+		<article className="mx-auto w-full max-w-4xl">
+			<div className="flex flex-col gap-8 px-6 py-16">
+				<Link
+					to="/{-$locale}/blog"
+					params={localeParams}
+					className="text-kicker hover:text-secondary"
+				>
+					{t((t) => t.blog.back)}
+				</Link>
+				<h1 className="text-heading text-center text-3xl md:text-5xl">
+					{displayTitle}
+				</h1>
+				<p className="text-kicker text-center text-sm">
+					{post.publishedAtLabel}
+				</p>
+				<div className="image-frame w-full aspect-video">
+					<span className="image-frame-overlay" aria-hidden="true" />
+					<ArticleImage
+						src={post.imageUrl}
+						alt={displayTitle}
+						className="image-treated relative h-full w-full object-cover"
+					/>
 				</div>
-			</article>
-		</div>
+				<MarkdownContent contentHtml={contentHtml} />
+				{seoOverride ? <SeoInsightSection override={seoOverride} /> : null}
+				<div className="mt-16 space-y-4">
+					<HeroIntroCard
+						heroPhotoUrl={heroPhotoUrl}
+						intro={t((t) => t.home.hero.intro)}
+						alt={t((t) => t.nav.brand)}
+					/>
+					<Button asChild>
+						<a
+							href={SCHEDULE_VISIO_URL}
+							target="_blank"
+							rel="noreferrer"
+							onClick={() =>
+								capture(ANALYTICS_EVENTS.ctaClick, {
+									cta: "schedule_call",
+									placement: "blog_post",
+									href: SCHEDULE_VISIO_URL,
+								})
+							}
+						>
+							{t((t) => t.blog.bookCtaButton)}
+							<ArrowUpRight className="size-4" />
+						</a>
+					</Button>
+				</div>
+
+				{suggestedArticles.length > 0 ? (
+					<div className="mt-16 border-t border-secondary/25 pt-16">
+						<h3 className="text-heading mb-8 text-center text-2xl">
+							{t((t) => t.blog.other)}
+						</h3>
+						<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-8">
+							{suggestedArticles.map((article) => (
+								<SuggestedArticleCard
+									key={article.slug}
+									article={article}
+									localeParams={localeParams}
+								/>
+							))}
+						</div>
+					</div>
+				) : null}
+			</div>
+		</article>
 	);
 }
 
@@ -209,10 +207,10 @@ function SeoInsightSection({
 			: { takeaways: "Key takeaways", faq: "Quick FAQ" };
 
 	return (
-		<section className="terminal-card mt-12 p-6">
-			<p className="terminal-label">{labels.takeaways}</p>
-			<p className="terminal-muted mt-3">{override.summary}</p>
-			<ul className="terminal-muted mt-5 space-y-3 text-sm">
+		<Card showPin={false} className="mt-12 p-6">
+			<p className="text-kicker">{labels.takeaways}</p>
+			<p className="text-body-muted mt-3">{override.summary}</p>
+			<ul className="text-body-muted mt-5 space-y-3 text-sm">
 				{override.keyPoints.map((point) => (
 					<li key={point} className="flex gap-3">
 						<span className="mt-1.5 shrink-0 text-secondary">&gt;</span>
@@ -221,17 +219,20 @@ function SeoInsightSection({
 				))}
 			</ul>
 			<div className="mt-8 space-y-4">
-				<h2 className="terminal-heading text-xl">{labels.faq}</h2>
+				<h2 className="text-heading text-xl">{labels.faq}</h2>
 				{override.faq.map((item) => (
-					<div key={item.question} className="terminal-divider border-t pt-4">
+					<div
+						key={item.question}
+						className="border-t border-secondary/25 pt-4"
+					>
 						<h3 className="text-base font-semibold text-foreground">
 							{item.question}
 						</h3>
-						<p className="terminal-muted mt-2 text-sm">{item.answer}</p>
+						<p className="text-body-muted mt-2 text-sm">{item.answer}</p>
 					</div>
 				))}
 			</div>
-		</section>
+		</Card>
 	);
 }
 

--- a/src/routes/{-$locale}/blog/index.tsx
+++ b/src/routes/{-$locale}/blog/index.tsx
@@ -30,34 +30,32 @@ export const Route = createFileRoute("/{-$locale}/blog/")({
 		});
 	},
 	pendingComponent: () => (
-		<div className="terminal-page">
-			<div className="py-24 md:py-28 px-6 max-w-6xl mx-auto">
-				<div className="text-center mb-16">
-					<Skeleton className="h-10 w-32 mx-auto mb-4" />
-					<Skeleton className="h-5 w-80 mx-auto" />
-				</div>
-				<div className="mb-16">
-					<div className="flex flex-col md:flex-row gap-8 md:items-center">
-						<Skeleton className="flex-1 aspect-[16/10]" />
-						<div className="flex-1">
-							<Skeleton className="h-10 w-3/4 mb-4" />
-							<Skeleton className="h-4 w-40" />
-						</div>
+		<div className="py-24 md:py-28 px-6 max-w-6xl mx-auto">
+			<div className="text-center mb-16">
+				<Skeleton className="h-10 w-32 mx-auto mb-4" />
+				<Skeleton className="h-5 w-80 mx-auto" />
+			</div>
+			<div className="mb-16">
+				<div className="flex flex-col md:flex-row gap-8 md:items-center">
+					<Skeleton className="flex-1 aspect-[16/10]" />
+					<div className="flex-1">
+						<Skeleton className="h-10 w-3/4 mb-4" />
+						<Skeleton className="h-4 w-40" />
 					</div>
 				</div>
-				<div>
-					<Skeleton className="h-7 w-40 mb-8" />
-					<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-						{[...Array(6)].map((_, i) => (
-							<div key={i} className="rounded-xl overflow-hidden">
-								<Skeleton className="aspect-[16/10] w-full" />
-								<div className="p-6">
-									<Skeleton className="h-4 w-28 mb-3" />
-									<Skeleton className="h-5 w-3/4" />
-								</div>
+			</div>
+			<div>
+				<Skeleton className="h-7 w-40 mb-8" />
+				<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+					{[...Array(6)].map((_, i) => (
+						<div key={i} className="overflow-hidden rounded-lg">
+							<Skeleton className="aspect-[16/10] w-full" />
+							<div className="p-6">
+								<Skeleton className="h-4 w-28 mb-3" />
+								<Skeleton className="h-5 w-3/4" />
 							</div>
-						))}
-					</div>
+						</div>
+					))}
 				</div>
 			</div>
 		</div>
@@ -74,7 +72,7 @@ function BlogListPage() {
 	const [featuredArticle, ...otherArticles] = posts;
 
 	return (
-		<div className="terminal-page">
+		<>
 			<ContentHero
 				label={t((t) => t.blog.heroLabel)}
 				title={t((t) => t.blog.heroTitle)}
@@ -83,7 +81,7 @@ function BlogListPage() {
 				descriptionClassName="mx-auto max-w-2xl"
 			/>
 
-			<section className="terminal-section mx-auto w-full max-w-6xl px-6 pb-20 pt-12">
+			<section className="section-divider mx-auto w-full max-w-6xl px-6 pb-20 pt-12">
 				{posts.length === 0 ? (
 					<ContentEmptyState>{t((t) => t.blog.empty)}</ContentEmptyState>
 				) : (
@@ -102,7 +100,7 @@ function BlogListPage() {
 
 						{otherArticles.length > 0 ? (
 							<div>
-								<h3 className="terminal-heading mb-8 text-2xl">
+								<h3 className="text-heading mb-8 text-2xl">
 									{t((t) => t.blog.latest)}
 								</h3>
 								<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
@@ -119,7 +117,7 @@ function BlogListPage() {
 					</>
 				)}
 			</section>
-		</div>
+		</>
 	);
 }
 

--- a/src/routes/{-$locale}/docs/$slug.tsx
+++ b/src/routes/{-$locale}/docs/$slug.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, notFound } from "@tanstack/react-router";
 import { marked } from "marked";
 import { ContentHero, DocumentCardLink } from "@/components/blocks/editorial";
 import MarkdownContent from "@/components/blocks/MarkdownContent";
+import { Card } from "@/components/ui/card";
 import { useContentReadTracking } from "@/lib/analytics";
 import { type DocSummary, directus } from "@/lib/directus";
 import { getTranslator } from "@/lib/i18n";
@@ -60,7 +61,7 @@ function DocsDetailPage() {
 	});
 
 	return (
-		<div className="terminal-page">
+		<>
 			<ContentHero
 				label={t((t) => t.docs.heroLabel)}
 				title={doc.title}
@@ -68,16 +69,16 @@ function DocsDetailPage() {
 				titleClassName="mt-4"
 			>
 				{doc.updatedAtLabel ? (
-					<p className="terminal-label mt-4 text-sm">
+					<p className="text-kicker mt-4 text-sm">
 						{t((t) => t.docs.effectiveDate)}: {doc.updatedAtLabel}
 					</p>
 				) : null}
 			</ContentHero>
 
-			<section className="terminal-section mx-auto w-full max-w-4xl px-6 pb-20 pt-12">
-				<div className="terminal-card p-8">
+			<section className="section-divider mx-auto w-full max-w-4xl px-6 pb-20 pt-12">
+				<Card showPin={false} className="p-8">
 					<MarkdownContent contentHtml={contentHtml} />
-				</div>
+				</Card>
 
 				{otherDocs.length > 0 ? (
 					<div className="mt-10 grid gap-4 md:grid-cols-2">
@@ -92,6 +93,6 @@ function DocsDetailPage() {
 					</div>
 				) : null}
 			</section>
-		</div>
+		</>
 	);
 }

--- a/src/routes/{-$locale}/docs/index.tsx
+++ b/src/routes/{-$locale}/docs/index.tsx
@@ -37,7 +37,7 @@ function DocsIndexPage() {
 		: {};
 
 	return (
-		<div className="terminal-page">
+		<>
 			<ContentHero
 				label={t((t) => t.docs.heroLabel)}
 				title={t((t) => t.docs.heroTitle)}
@@ -47,7 +47,7 @@ function DocsIndexPage() {
 				descriptionClassName="mt-4"
 			/>
 
-			<section className="terminal-section mx-auto w-full max-w-4xl px-6 pb-20 pt-12">
+			<section className="section-divider mx-auto w-full max-w-4xl px-6 pb-20 pt-12">
 				{docs.length === 0 ? (
 					<ContentEmptyState>{t((t) => t.docs.empty)}</ContentEmptyState>
 				) : (
@@ -58,7 +58,7 @@ function DocsIndexPage() {
 					</div>
 				)}
 			</section>
-		</div>
+		</>
 	);
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -8,25 +8,6 @@
 
 @custom-variant dark (&:is(.dark *));
 
-body {
-  @apply m-0;
-  font-family: 'Share Tech Mono', 'IBM Plex Mono', monospace;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-h1,
-h2,
-h3,
-h4 {
-  font-family: 'Share Tech Mono', 'IBM Plex Mono', monospace;
-}
-
-code {
-  font-family:
-    'IBM Plex Mono', Menlo, Monaco, Consolas, 'Courier New', monospace;
-}
-
 :root {
   --background: #10141f;
   --foreground: #f8f2dc;
@@ -42,8 +23,8 @@ code {
   --muted-foreground: #ccefd8;
   --accent: #ffd166;
   --accent-foreground: #10141f;
-  --destructive: #ff6b4a;
-  --destructive-foreground: #10141f;
+  --destructive: #e53e3e;
+  --destructive-foreground: #f8f2dc;
   --border: #a8ffcc;
   --input: #243047;
   --ring: #ffd166;
@@ -53,49 +34,7 @@ code {
   --chart-4: #f8f2dc;
   --chart-5: #7fd7ff;
   --radius: 0.25rem;
-  --terminal-navy: #10141f;
-  --terminal-panel: #1c2433;
-  --terminal-panel-2: #243047;
-  --terminal-phosphor: #a8ffcc;
-  --terminal-amber: #ffd166;
-  --terminal-coral: #ff6b4a;
-  --terminal-paper: #f8f2dc;
-  --terminal-shadow: #03060c;
-  --sidebar: #1c2433;
-  --sidebar-foreground: #f8f2dc;
-  --sidebar-primary: #ff6b4a;
-  --sidebar-primary-foreground: #10141f;
-  --sidebar-accent: #243047;
-  --sidebar-accent-foreground: #a8ffcc;
-  --sidebar-border: #a8ffcc;
-  --sidebar-ring: #ffd166;
-}
-
-.dark {
-  --background: #10141f;
-  --foreground: #f8f2dc;
-  --card: #1c2433;
-  --card-foreground: #f8f2dc;
-  --popover: #1c2433;
-  --popover-foreground: #f8f2dc;
-  --primary: #ff6b4a;
-  --primary-foreground: #10141f;
-  --secondary: #a8ffcc;
-  --secondary-foreground: #10141f;
-  --muted: #243047;
-  --muted-foreground: #ccefd8;
-  --accent: #ffd166;
-  --accent-foreground: #10141f;
-  --destructive: #ff6b4a;
-  --destructive-foreground: #10141f;
-  --border: #a8ffcc;
-  --input: #243047;
-  --ring: #ffd166;
-  --chart-1: #a8ffcc;
-  --chart-2: #ffd166;
-  --chart-3: #ff6b4a;
-  --chart-4: #f8f2dc;
-  --chart-5: #7fd7ff;
+  --shadow-hard: #03060c;
   --sidebar: #1c2433;
   --sidebar-foreground: #f8f2dc;
   --sidebar-primary: #ff6b4a;
@@ -131,10 +70,24 @@ code {
   --color-chart-3: var(--chart-3);
   --color-chart-4: var(--chart-4);
   --color-chart-5: var(--chart-5);
-  --radius-sm: calc(var(--radius) - 4px);
-  --radius-md: calc(var(--radius) - 2px);
+  --color-shadow-hard: var(--shadow-hard);
+  --font-display: 'Share Tech Mono', 'IBM Plex Mono', monospace;
+  --font-mono: 'IBM Plex Mono', Menlo, Monaco, Consolas, 'Courier New', monospace;
+  --radius-sm: calc(var(--radius) * 0.6);
+  --radius-md: calc(var(--radius) * 0.8);
   --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) + 4px);
+  --radius-xl: calc(var(--radius) * 1.4);
+  --radius-2xl: calc(var(--radius) * 1.8);
+  --shadow-hard-sm: 3px 3px 0 var(--shadow-hard);
+  --shadow-hard-md: 6px 6px 0 var(--shadow-hard);
+  --shadow-hard-lg: 8px 8px 0 var(--shadow-hard);
+  --shadow-hard-button: 4px 4px 0 var(--shadow-hard);
+  --animate-boot-line: boot-line 0.72s steps(8, end) both;
+  --animate-cursor-blink: cursor-blink 1s steps(2, end) infinite;
+  --animate-fade-up: fade-up 0.8s ease both;
+  --animate-float: float-slow 12s ease-in-out infinite;
+  --animate-terminal-reveal: terminal-reveal 0.6s steps(5, end) both;
+  --animate-crt-scan: crt-scan 4s steps(8, end) infinite alternate;
   --color-sidebar: var(--sidebar);
   --color-sidebar-foreground: var(--sidebar-foreground);
   --color-sidebar-primary: var(--sidebar-primary);
@@ -149,8 +102,20 @@ code {
   * {
     @apply border-border outline-ring/50;
   }
+
   body {
-    @apply bg-background text-foreground;
+    @apply m-0 bg-background font-display text-foreground antialiased;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4 {
+    @apply font-display;
+  }
+
+  code {
+    @apply font-mono;
   }
 }
 
@@ -160,6 +125,7 @@ code {
     transform: translateY(10px);
     clip-path: inset(0 100% 0 0);
   }
+
   100% {
     opacity: 1;
     transform: translateY(0);
@@ -172,6 +138,7 @@ code {
   45% {
     opacity: 1;
   }
+
   46%,
   100% {
     opacity: 0;
@@ -183,6 +150,7 @@ code {
     opacity: 0;
     transform: translateY(12px);
   }
+
   100% {
     opacity: 1;
     transform: translateY(0);
@@ -194,6 +162,7 @@ code {
     opacity: 0;
     transform: translateY(16px);
   }
+
   100% {
     opacity: 1;
     transform: translateY(0);
@@ -205,6 +174,7 @@ code {
   100% {
     transform: translateY(0);
   }
+
   50% {
     transform: translateY(-14px);
   }
@@ -214,6 +184,7 @@ code {
   0% {
     transform: translateY(-8px);
   }
+
   100% {
     transform: translateY(8px);
   }
@@ -227,6 +198,7 @@ code {
       100% 100%,
       0% 100%;
   }
+
   100% {
     background-position:
       100% 0%,
@@ -240,60 +212,134 @@ code {
   0% {
     transform: rotate(0turn);
   }
+
   100% {
     transform: rotate(1turn);
   }
 }
 
-@layer utilities {
-  .animate-fade-up {
-    animation: fade-up 0.8s ease both;
-  }
+@utility text-kicker {
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
 
-  .animate-float {
-    animation: float-slow 12s ease-in-out infinite;
-  }
+@utility text-heading {
+  color: var(--foreground);
+  font-weight: 400;
+  line-height: 0.98;
+  text-wrap: balance;
+}
 
-  .animate-terminal-reveal {
-    animation: terminal-reveal 0.6s steps(5, end) both;
+@utility text-body-muted {
+  color: color-mix(in srgb, var(--foreground) 78%, var(--secondary));
+  line-height: 1.65;
+}
+
+@utility section-hero {
+  position: relative;
+  overflow: hidden;
+  border-bottom: 2px solid color-mix(in srgb, var(--secondary) 50%, transparent);
+  background:
+    linear-gradient(
+      90deg,
+      color-mix(in srgb, var(--secondary) 6%, transparent) 1px,
+      transparent 1px
+    )
+    0 0 / 22px 22px,
+    linear-gradient(
+      color-mix(in srgb, var(--secondary) 4%, transparent) 1px,
+      transparent 1px
+    )
+    0 0 / 22px 22px;
+}
+
+@utility section-divider {
+  border-top: 2px solid color-mix(in srgb, var(--secondary) 24%, transparent);
+}
+
+@utility section-muted {
+  background: color-mix(in srgb, var(--card) 70%, transparent);
+}
+
+@utility text-cursor {
+  &::after {
+    content: "";
+    display: inline-block;
+    width: 0.55ch;
+    height: 0.78em;
+    margin-left: 0.08em;
+    background: var(--accent);
+    vertical-align: -0.08em;
+    animation: cursor-blink 1s steps(2, end) infinite;
   }
 }
 
+@utility image-frame {
+  position: relative;
+  overflow: hidden;
+  border: 2px solid var(--secondary);
+  border-radius: var(--radius);
+  background: var(--card);
+  box-shadow: var(--shadow-hard-md);
+}
+
+@utility image-frame-overlay {
+  pointer-events: none;
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(color-mix(in srgb, white 12%, transparent) 50%, transparent 50%)
+      0 0 / 100% 6px,
+    linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--secondary) 22%, transparent),
+      transparent 44%
+    );
+  mix-blend-mode: screen;
+  opacity: 0.34;
+}
+
+@utility image-treated {
+  filter: saturate(0.78) contrast(1.18);
+  transition:
+    transform 240ms steps(4, end),
+    filter 240ms steps(4, end);
+}
+
 @layer components {
-  .terminal-page {
+  .site-shell {
     position: relative;
     min-height: 100%;
     overflow: hidden;
     background:
       radial-gradient(
         circle at top right,
-        color-mix(in srgb, var(--terminal-amber) 16%, transparent),
+        color-mix(in srgb, var(--accent) 16%, transparent),
         transparent 34rem
       ),
       radial-gradient(
         circle at bottom left,
-        color-mix(in srgb, var(--terminal-phosphor) 12%, transparent),
+        color-mix(in srgb, var(--secondary) 12%, transparent),
         transparent 32rem
       ),
-      linear-gradient(180deg, var(--terminal-navy), #0c1019 64%, #090d15);
-    color: var(--terminal-paper);
+      linear-gradient(180deg, var(--background), #0c1019 64%, #090d15);
+    color: var(--foreground);
   }
 
-  .terminal-page::before {
+  .site-shell::before {
     content: "";
     position: fixed;
     inset: 0;
     z-index: 0;
     pointer-events: none;
     background:
-      linear-gradient(
-          color-mix(in srgb, white 6%, transparent) 50%,
-          transparent 50%
-        )
+      linear-gradient(color-mix(in srgb, white 6%, transparent) 50%, transparent 50%)
         0 0 / 100% 6px,
       linear-gradient(
         90deg,
-        color-mix(in srgb, var(--terminal-phosphor) 5%, transparent),
+        color-mix(in srgb, var(--secondary) 5%, transparent),
         transparent 18%,
         color-mix(in srgb, black 12%, transparent)
       );
@@ -301,135 +347,9 @@ code {
     animation: crt-scan 4s steps(8, end) infinite alternate;
   }
 
-  .terminal-page > * {
+  .site-shell > * {
     position: relative;
     z-index: 1;
-  }
-
-  .terminal-hero {
-    position: relative;
-    overflow: hidden;
-    border-bottom: 2px solid color-mix(in srgb, var(--terminal-phosphor) 50%, transparent);
-    background:
-      linear-gradient(
-        90deg,
-        color-mix(in srgb, var(--terminal-phosphor) 6%, transparent) 1px,
-        transparent 1px
-      )
-      0 0 / 22px 22px,
-      linear-gradient(
-        color-mix(in srgb, var(--terminal-phosphor) 4%, transparent) 1px,
-        transparent 1px
-      )
-      0 0 / 22px 22px;
-  }
-
-  .terminal-section {
-    border-top: 2px solid color-mix(in srgb, var(--terminal-phosphor) 24%, transparent);
-  }
-
-  .terminal-section-alt {
-    background: color-mix(in srgb, var(--terminal-panel) 70%, transparent);
-  }
-
-  .terminal-card {
-    position: relative;
-    border: 2px solid color-mix(in srgb, var(--terminal-phosphor) 58%, transparent);
-    border-radius: var(--radius);
-    background: color-mix(in srgb, var(--terminal-panel) 92%, transparent);
-    box-shadow: 6px 6px 0 var(--terminal-shadow);
-    color: var(--terminal-paper);
-    transition:
-      transform 160ms steps(2, end),
-      box-shadow 160ms steps(2, end),
-      border-color 160ms steps(2, end),
-      background-color 160ms steps(2, end);
-  }
-
-  .terminal-card::before {
-    content: "";
-    position: absolute;
-    top: 0.9rem;
-    right: 1rem;
-    width: 0.65rem;
-    height: 0.9rem;
-    background:
-      linear-gradient(var(--terminal-amber) 0 0) 0 0.35rem / 0.65rem 0.16rem,
-      linear-gradient(var(--terminal-amber) 0 0) 0.45rem 0.2rem / 0.16rem
-      0.16rem,
-      linear-gradient(var(--terminal-amber) 0 0) 0.45rem 0.5rem / 0.16rem
-      0.16rem;
-    background-repeat: no-repeat;
-    opacity: 0;
-    transition: opacity 160ms steps(2, end);
-  }
-
-  .terminal-card:hover,
-  .terminal-card:focus-within {
-    transform: translate(-2px, -2px);
-    border-color: var(--terminal-phosphor);
-    box-shadow: 8px 8px 0 var(--terminal-shadow);
-  }
-
-  .terminal-card:hover::before,
-  .terminal-card:focus-within::before {
-    opacity: 1;
-  }
-
-  .terminal-card-light {
-    border-color: var(--terminal-amber);
-    background: var(--terminal-paper);
-    color: var(--terminal-navy);
-  }
-
-  .terminal-label {
-    color: var(--terminal-amber);
-    font-size: 0.75rem;
-    letter-spacing: 0.18em;
-    text-transform: uppercase;
-  }
-
-  .terminal-heading {
-    color: var(--terminal-paper);
-    font-weight: 400;
-    line-height: 0.98;
-    letter-spacing: 0;
-    text-wrap: balance;
-  }
-
-  .terminal-card-light .terminal-heading,
-  .terminal-heading-dark {
-    color: var(--terminal-navy);
-  }
-
-  .terminal-muted {
-    color: color-mix(in srgb, var(--terminal-paper) 78%, var(--terminal-phosphor));
-    line-height: 1.65;
-  }
-
-  .terminal-card-light .terminal-muted,
-  .terminal-muted-dark {
-    color: color-mix(in srgb, var(--terminal-navy) 78%, black);
-  }
-
-  .terminal-chip {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.35rem;
-    border: 2px solid currentColor;
-    border-radius: var(--radius);
-    padding: 0.25rem 0.55rem;
-    background: color-mix(in srgb, var(--terminal-panel) 84%, transparent);
-    color: var(--terminal-phosphor);
-    font-size: 0.75rem;
-    line-height: 1.2;
-    text-transform: uppercase;
-    box-shadow: 3px 3px 0 var(--terminal-shadow);
-  }
-
-  .terminal-card-light .terminal-chip {
-    background: var(--terminal-navy);
-    color: var(--terminal-phosphor);
   }
 
   .migration-progress-board {
@@ -456,7 +376,7 @@ code {
     z-index: 1;
     min-height: 17rem;
     overflow: hidden;
-    background: color-mix(in srgb, var(--terminal-panel) 98%, black);
+    background: color-mix(in srgb, var(--card) 98%, black);
     width: 100%;
   }
 
@@ -467,28 +387,28 @@ code {
     z-index: 2;
     border-radius: calc(var(--radius) + 2px);
     background:
-      linear-gradient(90deg, transparent, var(--terminal-amber), transparent)
-      0 0 / 48% 3px no-repeat,
-      linear-gradient(180deg, transparent, var(--terminal-phosphor), transparent)
-      100% 0 / 3px 48% no-repeat,
-      linear-gradient(270deg, transparent, var(--terminal-amber), transparent)
-      100% 100% / 48% 3px no-repeat,
-      linear-gradient(0deg, transparent, var(--terminal-phosphor), transparent)
-      0 100% / 3px 48% no-repeat;
+      linear-gradient(90deg, transparent, var(--accent), transparent) 0 0 / 48% 3px
+        no-repeat,
+      linear-gradient(180deg, transparent, var(--secondary), transparent) 100% 0 /
+        3px 48% no-repeat,
+      linear-gradient(270deg, transparent, var(--accent), transparent) 100% 100% /
+        48% 3px no-repeat,
+      linear-gradient(0deg, transparent, var(--secondary), transparent) 0 100% /
+        3px 48% no-repeat;
     opacity: 0;
     pointer-events: none;
     transition: opacity 180ms steps(2, end);
   }
 
   .migration-progress-card[data-state="pending"] {
-    border-color: color-mix(in srgb, var(--terminal-paper) 28%, transparent);
+    border-color: color-mix(in srgb, var(--foreground) 28%, transparent);
   }
 
   .migration-progress-card[data-state="current"] {
-    border-color: var(--terminal-amber);
+    border-color: var(--accent);
     box-shadow:
-      8px 8px 0 var(--terminal-shadow),
-      0 0 0 1px color-mix(in srgb, var(--terminal-amber) 44%, transparent);
+      var(--shadow-hard-lg),
+      0 0 0 1px color-mix(in srgb, var(--accent) 44%, transparent);
   }
 
   .migration-progress-card[data-state="current"]::after {
@@ -497,7 +417,7 @@ code {
   }
 
   .migration-progress-card[data-state="done"] {
-    border-color: var(--terminal-phosphor);
+    border-color: var(--secondary);
   }
 
   .migration-progress-node {
@@ -508,17 +428,17 @@ code {
     place-items: center;
     border: 2px solid currentColor;
     border-radius: var(--radius);
-    background: var(--terminal-navy);
-    color: var(--terminal-phosphor);
-    box-shadow: 4px 4px 0 var(--terminal-shadow);
+    background: var(--background);
+    color: var(--secondary);
+    box-shadow: var(--shadow-hard-button);
   }
 
   .migration-progress-card[data-state="pending"] .migration-progress-node {
-    color: color-mix(in srgb, var(--terminal-paper) 46%, transparent);
+    color: color-mix(in srgb, var(--foreground) 46%, transparent);
   }
 
   .migration-progress-card[data-state="current"] .migration-progress-node {
-    color: var(--terminal-amber);
+    color: var(--accent);
   }
 
   .migration-progress-status {
@@ -530,20 +450,20 @@ code {
     border: 2px solid currentColor;
     border-radius: var(--radius);
     padding: 0.32rem 0.6rem;
-    background: var(--terminal-navy);
-    color: color-mix(in srgb, var(--terminal-paper) 68%, transparent);
+    background: var(--background);
+    color: color-mix(in srgb, var(--foreground) 68%, transparent);
     font-size: 0.72rem;
     line-height: 1.1;
     text-transform: uppercase;
-    box-shadow: 3px 3px 0 var(--terminal-shadow);
+    box-shadow: var(--shadow-hard-sm);
   }
 
   .migration-progress-status[data-state="current"] {
-    color: var(--terminal-amber);
+    color: var(--accent);
   }
 
   .migration-progress-status[data-state="done"] {
-    color: var(--terminal-phosphor);
+    color: var(--secondary);
   }
 
   .migration-progress-spinner {
@@ -564,9 +484,9 @@ code {
     display: flex;
     align-items: flex-start;
     gap: 0.5rem;
-    border-top: 1px solid color-mix(in srgb, var(--terminal-phosphor) 26%, transparent);
+    border-top: 1px solid color-mix(in srgb, var(--secondary) 26%, transparent);
     padding-top: 1rem;
-    color: var(--terminal-phosphor);
+    color: var(--secondary);
     font-size: 0.875rem;
     line-height: 1.5;
   }
@@ -578,10 +498,6 @@ code {
       gap: 6rem 4rem;
       min-height: 42rem;
       padding: 2.5rem 0;
-    }
-
-    .migration-progress-grid::before {
-      display: none;
     }
 
     .migration-progress-path {
@@ -603,15 +519,15 @@ code {
     }
 
     .migration-progress-path-track {
-      stroke: color-mix(in srgb, var(--terminal-phosphor) 34%, transparent);
+      stroke: color-mix(in srgb, var(--secondary) 34%, transparent);
       stroke-width: 4;
     }
 
     .migration-progress-path-progress {
-      stroke: var(--terminal-amber);
+      stroke: var(--accent);
       stroke-width: 5;
       stroke-dasharray: var(--migration-progress) 1;
-      filter: drop-shadow(4px 4px 0 var(--terminal-shadow));
+      filter: drop-shadow(4px 4px 0 var(--shadow-hard));
       transition: stroke-dasharray 820ms cubic-bezier(0.22, 1, 0.36, 1);
     }
 
@@ -652,67 +568,6 @@ code {
     }
   }
 
-  .terminal-image-frame {
-    position: relative;
-    overflow: hidden;
-    border: 2px solid var(--terminal-phosphor);
-    border-radius: var(--radius);
-    background: var(--terminal-panel);
-    box-shadow: 6px 6px 0 var(--terminal-shadow);
-  }
-
-  .terminal-image-frame::after {
-    content: "";
-    position: absolute;
-    inset: 0;
-    pointer-events: none;
-    background:
-      linear-gradient(
-          color-mix(in srgb, white 12%, transparent) 50%,
-          transparent 50%
-        )
-        0 0 / 100% 6px,
-      linear-gradient(
-        135deg,
-        color-mix(in srgb, var(--terminal-phosphor) 22%, transparent),
-        transparent 44%
-      );
-    mix-blend-mode: screen;
-    opacity: 0.34;
-  }
-
-  .terminal-image {
-    filter: saturate(0.78) contrast(1.18);
-    image-rendering: auto;
-    transition:
-      transform 240ms steps(4, end),
-      filter 240ms steps(4, end);
-  }
-
-  .group:hover .terminal-image {
-    transform: scale(1.025);
-    filter: saturate(0.95) contrast(1.28);
-  }
-
-  .terminal-boot-line {
-    animation: boot-line 0.72s steps(8, end) both;
-  }
-
-  .terminal-cursor::after {
-    content: "";
-    display: inline-block;
-    width: 0.55ch;
-    height: 0.78em;
-    margin-left: 0.08em;
-    background: var(--terminal-amber);
-    vertical-align: -0.08em;
-    animation: cursor-blink 1s steps(2, end) infinite;
-  }
-
-  .terminal-divider {
-    border-color: color-mix(in srgb, var(--terminal-phosphor) 26%, transparent);
-  }
-
   .testimonial-console {
     isolation: isolate;
   }
@@ -722,9 +577,9 @@ code {
     align-items: center;
     justify-content: space-between;
     gap: 1rem;
-    border-bottom: 2px solid color-mix(in srgb, var(--terminal-phosphor) 42%, transparent);
-    background: color-mix(in srgb, var(--terminal-navy) 72%, var(--terminal-panel));
-    color: var(--terminal-amber);
+    border-bottom: 2px solid color-mix(in srgb, var(--secondary) 42%, transparent);
+    background: color-mix(in srgb, var(--background) 72%, var(--card));
+    color: var(--accent);
     font-size: 0.72rem;
     letter-spacing: 0.16em;
     line-height: 1.4;
@@ -743,14 +598,11 @@ code {
     inset: 0;
     pointer-events: none;
     background:
-      linear-gradient(
-          color-mix(in srgb, var(--terminal-phosphor) 7%, transparent) 50%,
-          transparent 50%
-        )
+      linear-gradient(color-mix(in srgb, var(--secondary) 7%, transparent) 50%, transparent 50%)
         0 0 / 100% 8px,
       radial-gradient(
         circle at 8% 8%,
-        color-mix(in srgb, var(--terminal-amber) 16%, transparent),
+        color-mix(in srgb, var(--accent) 16%, transparent),
         transparent 18rem
       );
     opacity: 0.36;
@@ -771,7 +623,7 @@ code {
 
   .testimonial-console-name {
     position: relative;
-    color: var(--terminal-phosphor);
+    color: var(--secondary);
     font-size: 1rem;
     line-height: 1.2;
     text-transform: uppercase;
@@ -780,8 +632,8 @@ code {
   .testimonial-console-quote {
     position: relative;
     margin-top: 2rem;
-    color: var(--terminal-paper);
-    font-family: 'IBM Plex Mono', monospace;
+    color: var(--foreground);
+    font-family: var(--font-mono);
     font-size: 1.05rem;
     line-height: 1.75;
     text-wrap: pretty;
@@ -792,20 +644,9 @@ code {
     width: 0.55ch;
     height: 1em;
     margin-left: 0.16rem;
-    background: var(--terminal-amber);
+    background: var(--accent);
     vertical-align: -0.12em;
     animation: cursor-blink 1s steps(2, end) infinite;
-  }
-
-  .terminal-prose {
-    font-family: 'IBM Plex Mono', monospace;
-  }
-
-  .terminal-prose h1,
-  .terminal-prose h2,
-  .terminal-prose h3,
-  .terminal-prose h4 {
-    font-family: 'Share Tech Mono', 'IBM Plex Mono', monospace;
   }
 }
 
@@ -832,19 +673,6 @@ code {
   }
 }
 
-.cv-section-title {
-  font-size: 0.72rem;
-  font-weight: 600;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: #475569;
-}
-
-.cv-avoid-break {
-  break-inside: avoid;
-  page-break-inside: avoid;
-}
-
 @page {
   size: A4;
   margin: 0;
@@ -857,78 +685,5 @@ code {
     color: #0f172a !important;
     -webkit-print-color-adjust: exact;
     print-color-adjust: exact;
-  }
-
-  .cv-page {
-    background: #ffffff !important;
-    padding: 0 !important;
-  }
-
-  .cv-sheet {
-    width: 210mm !important;
-    max-width: 210mm !important;
-    min-height: 297mm;
-    margin: 0 !important;
-    border: 0 !important;
-    border-radius: 0 !important;
-    box-shadow: none !important;
-  }
-
-  .cv-sheet a {
-    color: #0f172a !important;
-    text-decoration: underline !important;
-  }
-
-  .cv-header-grid {
-    grid-template-columns: 1.45fr 0.75fr !important;
-    align-items: start !important;
-  }
-
-  .cv-header-aside {
-    justify-self: end !important;
-  }
-
-  .cv-contact-icons {
-    justify-content: flex-end !important;
-  }
-
-  .cv-avatar,
-  .cv-icon-badge {
-    box-shadow: none !important;
-    outline: none !important;
-  }
-
-  .cv-avatar {
-    border-radius: 9999px !important;
-    overflow: hidden !important;
-  }
-
-  .cv-icon-badge {
-    border-radius: 9999px !important;
-    text-decoration: none !important;
-  }
-
-  .cv-section {
-    margin-top: 0.75rem !important;
-  }
-
-  .cv-list-item {
-    padding-bottom: 0.45rem !important;
-  }
-
-  .cv-detail-list {
-    margin-top: 0.3rem !important;
-    gap: 0.1rem !important;
-    padding-left: 0.9rem !important;
-  }
-
-  .cv-detail-list li {
-    font-size: 11.5px !important;
-    line-height: 1.2 !important;
-  }
-
-  .cv-detail-text {
-    font-size: 12px !important;
-    line-height: 1.25 !important;
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Merges the custom `terminal-*` CSS system into Tailwind v4 theme tokens and default shadcn primitives, so the terminal aesthetic is the only design language — no separate terminal-named components.

## Changes

### Theme (`src/styles.css`)
- Unified shadcn semantic tokens as the single source of truth (removed duplicate `--terminal-*` vars)
- Added Tailwind theme extensions: `shadow-hard-*`, `font-display`, `font-mono`, custom animations
- Added `@utility` helpers: `text-kicker`, `text-heading`, `text-body-muted`, `image-frame`, `section-hero`, `section-divider`, `section-muted`, `text-cursor`
- Moved CRT page shell to `.site-shell` (applied once in `RootShell`)
- Kept co-located CSS only for `migration-*` and `testimonial-*` widgets
- Differentiated `--destructive` from `--primary`

### New shadcn primitives
- **`Card`** — default variant matches former `.terminal-card` (hard shadow, 2px border, hover lift, pin decoration)
- **`Badge`** — default variant matches former `.terminal-chip`

### Aligned ui components
- `Button`, `NavigationMenu` (updated shadow tokens)
- `Input`, `Textarea`, `Select`, `Switch`, `Slider`, `Tooltip`, `Sheet`, `Separator`, `Skeleton`
- Fixed invalid `hsl(var(--sidebar-border))` in sidebar

### Block/route migration (~20 files)
- Replaced `terminal-card` → `<Card>` / `cardVariants()`
- Replaced `terminal-chip` → `<Badge>`
- Replaced `terminal-heading/label/muted` → `text-heading`, `text-kicker`, `text-body-muted`
- Replaced `terminal-image-frame` → `image-frame` utility + overlay span
- Removed per-page `terminal-page` wrappers (handled by `RootShell`)
- CV print styles migrated to Tailwind `print:` utilities

## Verification

- `npm run check` passes (Biome + tsc)
- `npm run build` passes
- No remaining `terminal-*` or `cv-*` class references in TSX

## Notes

- CV route keeps its separate paper/slate print aesthetic (intentional)
- `app-sidebar.tsx` / `nav-main.tsx` remain unused dead code; sidebar restyled but not removed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f245b-9526-7986-883a-458f46047530"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f245b-9526-7986-883a-458f46047530"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

