### PR TITLE
Centrer le menu header sur petit écran

### DIFF
--- a/src/components/blocks/Header.tsx
+++ b/src/components/blocks/Header.tsx
@@ -80,8 +80,8 @@ export default function Header({ blogPosts = [] }: HeaderProps) {
 	return (
 		<header className="sticky top-0 z-50 border-b-2 border-secondary/50 bg-background/92 backdrop-blur">
 			<div className="mx-auto flex w-full max-w-6xl flex-col gap-4 px-6 py-4 md:flex-row md:items-center md:justify-between">
-				<div className="flex items-center justify-between gap-4 md:contents">
-					<div className="flex min-w-0 items-center gap-6">
+				<div className="relative flex items-center justify-between gap-4 md:contents">
+					<div className="relative z-10 flex min-w-0 items-center gap-6">
 						<Link
 							to="/{-$locale}"
 							params={localeParams}
@@ -93,9 +93,9 @@ export default function Header({ blogPosts = [] }: HeaderProps) {
 							{t((t) => t.nav.tagline)}
 						</span>
 					</div>
-					<nav className="flex shrink-0 items-center gap-4 text-sm text-muted-foreground md:gap-6">
-						<NavigationMenu className="max-w-max flex-none justify-start">
-							<NavigationMenuList className="flex flex-nowrap justify-start gap-2">
+					<nav className="pointer-events-none absolute inset-x-0 flex items-center justify-center text-sm text-muted-foreground md:pointer-events-auto md:static md:inset-auto md:shrink-0 md:items-center md:gap-6">
+						<NavigationMenu className="pointer-events-auto w-[calc(100vw-3rem)] max-w-[calc(100vw-3rem)] flex-none justify-center md:w-auto md:max-w-max md:justify-start">
+							<NavigationMenuList className="flex flex-nowrap justify-center gap-2 md:justify-start">
 								<NavigationMenuItem>
 									<NavigationMenuTrigger className={triggerClassName}>
 										{t((t) => t.nav.about)}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sur petit écran, le menu déroulant du header (À propos / Blog) s’alignait à droite et dépassait de l’écran. Le panneau est maintenant centré dans la zone utile du header.

## Changements

- Sur mobile : la nav est positionnée en pleine largeur et centrée, avec un conteneur `NavigationMenu` calé sur `calc(100vw - 3rem)` (marges du header)
- Sur `md+` : comportement inchangé grâce aux classes `md:*` existantes

## Test plan

- [x] Build OK
- [ ] Vérifier sur mobile que les menus À propos et Blog s’ouvrent centrés sans débordement horizontal
- [ ] Vérifier sur desktop que le header reste identique
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2463-cc61-7071-b281-cff1a4ded269"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2463-cc61-7071-b281-cff1a4ded269"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

